### PR TITLE
Update new Oracle SWE openings

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,10 +85,10 @@ And we're back! Use this repo to share and keep track of software, tech, CS, PM,
 | [Neocis](https://www.neocis.com/careers/?gnk=job&gni=8a7887ac81818f790181a70be60322fb&lang=en)| Miami, FL | Software Engineering Internship |
 | [Hewlett Packard Enterprise](https://careers.hpe.com/us/en/search-results?keywords=software%20intern) | Multiple Locations in United States | Software Developer Intern, Software Engineering Intern
 | [Ocient](https://boards.greenhouse.io/ocient39/jobs/5213072003)| Remote | Software Engineer Internship
-| [Oracle](https://eeho.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1/job/175530?utm_medium=jobboard&utm_source=LinkedIn) | United States | Software Engineer Intern - Corporate Architecture
 | [Blackstone](https://blackstone.wd1.myworkdayjobs.com/en-US/Blackstone_Campus_Careers/details/XMLNAME-2023-Blackstone-Technology-and-Innovations--Software-Developer-Summer-Analyst--New-York-_23913) | Miami, New York | Software Developer Summer Analyst |
 | [Kodiak](https://jobs.lever.co/kodiak?commitment=Intern) | Mountain View, CA | [Software Engineering Internship](https://jobs.lever.co/kodiak/3b6b45b7-0b31-45cc-bcd5-4720cd5ae913), [Deep Learning for Computer Vision Internship](https://jobs.lever.co/kodiak/34ed52b0-6cf5-4cd6-aef6-af42ff89f261) |
 | [Northrop Grumman](https://www.northropgrumman.com/jobs/Melbourne-----Florida/Administrative-Services/R10055512/2023-intern-software-engineer/) | Melbourne, FL | Software Engineer Intern |
+| [Oracle](https://eeho.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1/requisitions?keyword=engineering+intern) | United States | Multiple Software Engineer Interns - Corporate Architecture/Analytics Cloud/DB and Systems/Netsuite, etc.
 
 ## We love our contributors ❤️❤️
 Make a [pull request](https://github.com/susam/gitpr#create-pull-request) to help contribute.


### PR DESCRIPTION
New Oracle openings on Jul 15th, following the first intern position released on Jul 13th.