### PR TITLE
ServiceNow closed.

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ And we're back! Use this repo to share and keep track of software, tech, CS, PM,
 | [Streamforge](https://angel.co/l/2vvkF3) | Remote | Videogames + Influencer Marketing + Twitch Streaming + YouTubers / [Software Engineer Position Summer 2023](https://angel.co/l/2vvkF3) |
 | [Seven Eight Capital](https://boards.greenhouse.io/seveneightcapital/jobs/4477864002)| New York, Boston, Samford | Software Engineer Internship
 | [Databento](https://boards.greenhouse.io/databento/jobs/4374815?)| Remote | SWE Intern (H1B sponsorship available)
-| [ServiceNow](https://careers.servicenow.com/careers/jobs/743999840818371EXT?lang=en-us&src=linkedin&sid=2d92f286-613b-4daf-9dfa-6340ffbecf73)| Remote | Database Software Engineer Intern
+| ServiceNow| Remote | **Closed:** Database Software Engineer Intern
 | [Virtu Financial](https://boards.greenhouse.io/virtu/jobs/5432329002)| New York, NY | Internship - Developer (10 weeks Summer 2023)
 | [Prudential](https://prudential.eightfold.ai/careers?pid=12393231&Job%20Category=Technology&location_country=US&early_talent=Summer%20Internships&domain=prudential.com)| Newark, NJ | Software Engineering Summer Internship Program
 | [PDT Partners](https://boards.greenhouse.io/pdtpartners/jobs/4423823)| New York, NY | Software Engineering Internship (10 weeks Summer 2023)


### PR DESCRIPTION
The original [link](https://careers.servicenow.com/careers/jobs/743999840818371EXT?lang=en-us&src=linkedin&sid=2d92f286-613b-4daf-9dfa-6340ffbecf73) points to a 404 page and I don't see any other similar US internships on their website at this time.