### PR TITLE
Removed: Retool Mobile

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,6 @@ And we're back! Use this repo to share and keep track of software, tech, CS, PM,
 | [Proofpoint](https://proofpoint.wd5.myworkdayjobs.com/ProofpointCareers/job/Broomfield-CO/Software-Developer-Summer-Intern---Undergrad_R8332) | Broomfield, CO | Software Developer Intern |
 | [ServiceNow](https://careers.servicenow.com/careers/jobs/743999845895131EXT?lang=en-us&src=linkedin&sid=2d92f286-613b-4daf-9dfa-6340ffbecf73)| Santa Clara, CA | Software Engineering Intern
 | [Convoy](https://boards.greenhouse.io/convoy/jobs/4631008004?gh_src=f0b55ea54us) | Seattle, WA | Software Engineer Intern |
-| [Retool Mobile](https://retool.com/products/mobile/) | SF | |
 
 <!-- Please leave a one line gap between this and the table -->
 [⬆️ Back to Top ⬆️](https://github.com/pittcsc/Summer2023-Internships#the-list-)


### PR DESCRIPTION
I'm not sure why this is in the internship list when the link doesn't point to the application page or even the careers page, and there's apparently not even an internship position listed in their careers page.

Is there a reason behind it? 