### PR TITLE
Close Lime

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ And we're back! Use this repo to share and keep track of software, tech, CS, PM,
 | [Proofpoint](https://proofpoint.wd5.myworkdayjobs.com/ProofpointCareers/job/Broomfield-CO/Software-Developer-Summer-Intern---Undergrad_R8332) | Broomfield, CO | Software Developer Intern |
 | [ServiceNow](https://careers.servicenow.com/careers/jobs/743999845895131EXT?lang=en-us&src=linkedin&sid=2d92f286-613b-4daf-9dfa-6340ffbecf73)| Santa Clara, CA | Software Engineering Intern
 | [Convoy](https://boards.greenhouse.io/convoy/jobs/4631008004?gh_src=f0b55ea54us) | Seattle, WA | Software Engineer Intern |
-| [Lime](https://jobs.lever.co/lime/70477592-6eae-4fac-a33d-1c60e9177301?lever-origin=applied&lever-source%255B%255D=linkedin-job-wrapping) | SF,CA | SWE Intern |
+| [Lime](https://jobs.lever.co/lime/70477592-6eae-4fac-a33d-1c60e9177301?lever-origin=applied&lever-source%255B%255D=linkedin-job-wrapping) | SF,CA | **🔒 Closed 🔒** SWE Intern |
 | [Daikin](https://recruiting.adp.com/srccar/public/nghome.guid?c=1143611&d=External&prc=RMPOD3&r=5000877708900#/) | Plymouth, MN | SWE Intern (No Sponsorship) |
 | [Lyft](https://www.lyft.com/careers/early-talent) | Multiple Locations in the US | SWE Intern Generalist, SWE Intern Frontend |
 


### PR DESCRIPTION
Looks like internship apps for Lime have closed. The link returns a 404 and the [LinkedIn page](https://www.linkedin.com/jobs/view/software-engineering-intern-summer-2023-at-lime-3228294985/) says no longer accepting submissions.