### PR TITLE
Correct link for Seven Eight Capital position

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ And we're back! Use this repo to share and keep track of software, tech, CS, PM,
 | [Jane Street](https://www.janestreet.com/join-jane-street/position/6213528002/) | New York | Software Engineer Summer Internship 2023
 | [Asana](https://boards.greenhouse.io/earlycareerprograms) | San Francisco, New York City, Vancouver | Summer 2023 Engineering Internship|
 | [Streamforge](https://angel.co/l/2vvkF3) | Remote | Videogames + Influencer Marketing + Twitch Streaming + YouTubers / [Software Engineer Position Summer 2023](https://angel.co/l/2vvkF3) |
-| [Seven Eight Capital](https://boards.greenhouse.io/seveneightcapital/jobs/4477864002)| New York, Boston, Stamford | Software Engineer Internship
+| [Seven Eight Capital](https://boards.greenhouse.io/seveneightcapital/jobs/6304824002?gh_jid=6304824002)| New York, Boston, Stamford | Software Engineer Internship
 | [Databento](https://boards.greenhouse.io/databento/jobs/4374815?)| Remote | SWE Intern (H1B sponsorship available)
 | ServiceNow| Remote | **🔒 Closed 🔒** Database Software Engineer Intern
 | [Virtu Financial](https://boards.greenhouse.io/virtu/jobs/5432329002)| New York, NY | Internship - Developer (10 weeks Summer 2023)


### PR DESCRIPTION
Hi!

The link for the Seven Eight Capital position actually points to a[ "Software Engineer" position](https://boards.greenhouse.io/seveneightcapital/jobs/4477864002), rather than an [internship position](https://boards.greenhouse.io/seveneightcapital/jobs/6304824002?gh_jid=6304824002). 

I have found the mistake and corrected it in this PR. 

Appreciate your review. Thanks!