### PR TITLE
Add Whatnot internship.

### DIFF
--- a/README.md
+++ b/README.md
@@ -595,6 +595,7 @@ And we're back! Use this repo to share and keep track of software, tech, CS, PM,
 | [Commonwealth](https://careers-commonwealth.icims.com/jobs/5581/2023-summer-internship-program/job) | Waltham, MA | General Summer Internship Application for all departments (cover letter required) |
 | [Chamberlain Group](https://chamberlain.wd1.myworkdayjobs.com/en-US/Chamberlain_Group?workerSubType=a1d19ddc127d10332f2265ab00be635b) | Oak Brook, IL | 2023 Summer internships for SWE, Data, PM, etc. |
 | [Rockwell Automation](https://rockwellautomation.wd1.myworkdayjobs.com/en-US/External_Rockwell_Automation/job/Intern--Information-Technology_R22-8470-2?Codes=ILINK) | Milwaukee, WI | IT Intern (No Sponsorship) |
+| [Whatnot](https://boards.greenhouse.io/whatnot/jobs/4604514004) | Remote | Software Engineering Intern (No Sponsorship) |
 
 <!-- Please leave a one line gap between this and the table -->
 [⬆️ Back to Top ⬆️](https://github.com/pittcsc/Summer2023-Internships#the-list-)


### PR DESCRIPTION
Adding [Whatnot's Internship Position](https://boards.greenhouse.io/whatnot/jobs/4604514004). But what is [Whatnot](https://whatnot.com/)? Think Twitch meets eBay.

We're the [fastest growing marketplace of all time](https://znsrc.com/c/iexuryoimz) ([for 2 years in a row](https://znsrc.com/c/uhkwywkapb)) and we raised a $260M series D just this year from DST Global, A16z, YC, Bond Capital, and CapitalG at a $3.7B valuation.

Whatnot is perfectly positioned in the livestream shopping space, which is already big in China, as e-commerce continues to explode (Shopify + Amazon) in tandem with increased consumer video adoption (Youtube + TikTok).

Our interns work in cross-functional multidisciplinary teams enabling you to directly impact the direction of our platform. Your design, code, and ideas will contribute to solving some of the most complex technical challenges we face today and define future engineering initiatives. 