### PR TITLE
Mark Tackle.io posting as closed

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,7 +396,7 @@ And we're back! Use this repo to share and keep track of software, tech, CS, PM,
 | CSG | Remote | **🔒 Closed 🔒** Software Engineer Intern - C# |
 | [Achieve](https://jobs.jobvite.com/achieve/job/ohVclfwt) | Remote | Intern, Software Development |
 | [Lennox International](https://uscareers-lennox.icims.com/jobs/34333/software-engineer-intern---summer-2023/job) | Carrollton, TX | Software Engineer Intern - Summer 2023 |
-| [Tackle.io](https://jobs.lever.co/tackle/379afe16-73ce-4eff-8b73-d3801f5a26fc) | Remote | Software Engineer- Summer Associate |
+| Tackle.io | Remote | **🔒 Closed 🔒** Software Engineer- Summer Associate |
 | AT&T | Multiple Locations | **🔒 Closed 🔒** EDGE Internship Program 2023 (No Visa Sponsorship) |
 | Khan Academy | Remote | **🔒 Closed 🔒** Software Engineer Intern |
 | SoFi | Multiple Locations | **🔒 Closed 🔒** Intern, Software Engineer |


### PR DESCRIPTION
Tackle has completed the hiring process for 2023 interns and the posting is closed. This PR removes the link for Tackle.