### PR TITLE
Create New README for 2024 Internships

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,9 +13,10 @@ We ask that the internships that you add meet some requirements. Specifically, y
     - product manager,
     - quant, and
     - any other tech-related internships.
-- be for **summer 2023**. We will *not* accept internships for a different term.
+- be for **summer 2023** or **summer 2024**. We will *not* accept internships for a different term.
 - be located in the United States, Canada, or remote.
 - not already exist in the internship list, and must not be pending review [here](https://github.com/pittcsc/Summer2023-Internships/pulls). 
+    - Note that we have two separate READMEs; one for [Summer 2023 internships](https://github.com/pittcsc/Summer2023-Internships/blob/dev/README.md) and one for [Summer 2024 internships](https://github.com/pittcsc/Summer2023-Internships/blob/dev/README-2024.md). Be sure you're contributing to the correct one.
 
 Make sure to have the following information ready:
 - The name of the position.

--- a/README-2024.md
+++ b/README-2024.md
@@ -1,6 +1,6 @@
 
 # Summer 2024 Tech Internships by Pitt CSC 🌆🐢
-And we're back! Use this repo to share and keep track of software, tech, CS, PM, quant internships for Summer 2023. List maintained by [the Pitt Computer Science Club](https://pittcsc.org/)!
+And we're back! Use this repo to share and keep track of software, tech, CS, PM, quant internships for **Summer 2024**. List maintained by [the Pitt Computer Science Club](https://pittcsc.org/)!
 
 :warning: **This repository is only for internships/co-ops in the United States, Canada or for Remote positions :earth_americas:.**
 

--- a/README-2024.md
+++ b/README-2024.md
@@ -1,0 +1,57 @@
+
+# Summer 2024 Tech Internships by Pitt CSC 🌆🐢
+And we're back! Use this repo to share and keep track of software, tech, CS, PM, quant internships for Summer 2023. List maintained by [the Pitt Computer Science Club](https://pittcsc.org/)!
+
+:warning: **This repository is only for internships/co-ops in the United States, Canada or for Remote positions :earth_americas:.**
+
+🧠 For tips on the internship process check out the [Zero to Offer](https://www.pittcs.wiki/zero-to-offer) 🧠
+
+🙏 **Contribute by submitting a [pull request](https://github.com/susam/gitpr#create-pull-request)! See the contribution guidelines [here](https://github.com/pittcsc/Summer2023-Internships/blob/dev/CONTRIBUTING.md)!** 🙏
+
+---
+<div align="center">
+	<p>
+		<a href="https://simplify.jobs/?utm_source=pittcsc&utm_medium=internships_repo">
+			<b>Applying to internships?</b>
+			<br>
+			Autofill all your applications in a single click.
+			<br>
+			<div>
+				<a href="https://simplify.jobs/?utm_source=pittcsc&utm_medium=internships_repo"><img src="https://res.cloudinary.com/dpeo4xcnc/image/upload/v1636594918/simplify_pittcsc.png" width="450" alt="Simplify" ></a>
+			</div>
+		</a>
+		<sub><i>Stop manually re-entering your information. Simplify’s extension helps you autofill internship applications on millions of sites.</i></sub>
+	</p>
+</div>
+
+<div align="center">
+	<h3>
+		Thanks for a great three years 💖💖
+	</h3>
+	<p>
+		<img src="https://api.star-history.com/svg?repos=pittcsc/Summer2023-Internships&type=Date" width="500"  alt="Star History">
+	</p>
+</div>
+
+---
+
+## The List 🚴🏔
+> **Note**:
+> This README file is for **2024 internships only**. For 2023 internships, please [click here](https://github.com/pittcsc/Summer2023-Internships/blob/dev/README.md).
+
+[⬇️ Jump to bottom ⬇️](https://github.com/pittcsc/Summer2023-Internships#we-love-our-contributors-%EF%B8%8F%EF%B8%8F)
+<!-- Please leave a one line gap between this and the table -->
+
+| Name | Location | Notes |
+| ---- | -------- | ----- |
+| [Goldman Sachs](https://www.goldmansachs.com/careers/students/programs/americas/summer-analyst-program.html) | Global | Summer 2024 Analyst |
+
+<!-- Please leave a one line gap between this and the table -->
+[⬆️ Back to Top ⬆️](https://github.com/pittcsc/Summer2023-Internships#the-list-)
+
+## We love our contributors ❤️❤️
+Make a [pull request](https://github.com/susam/gitpr#create-pull-request) to help contribute.
+<a href="https://github.com/pittcsc/Summer2023-Internships/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=pittcsc/Summer2023-Internships&columns=24&max=480" />
+</a>
+*Made with [contrib.rocks](https://contrib.rocks).*

--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ And we're back! Use this repo to share and keep track of software, tech, CS, PM,
 ---
 
 ## The List 🚴🏔
+> **Note**:
+> This README file is for **2023 internships only**. For 2024 internships, please [click here](https://github.com/pittcsc/Summer2023-Internships/blob/dev/README-2024.md).
+
 [⬇️ Jump to bottom ⬇️](https://github.com/pittcsc/Summer2023-Internships#we-love-our-contributors-%EF%B8%8F%EF%B8%8F)
 <!-- Please leave a one line gap between this and the table -->
 


### PR DESCRIPTION
Following the discussion in #1838, I've decided to make a separate README for 2024 internships. 

Justification
- Most people using this repository are looking for 2023 internships, not 2024 internships.
- There probably aren't many 2024 internship postings right now. 
- Putting 2024 internships in the same file as 2023 internships may cause confusion, something we're trying to limit. 
- I don't want to potentially break the `sync.py` script, which appears to be using the default README file.
- Because of the above points, it doesn't make a lot of sense to 
  - create a dedicated table for 2024 internships, 
  - put 2024 internships in the same table as 2023 internships. 

At the same time, because 2024 internship postings are apparently just starting to come out, we should start adding them to a dedicated list. Once the 2023 internship season is over, we can merge the 2024 README to the 2023 README file and delete the 2024 README file. 

Let me know what your thoughts are. 