### PR TITLE
Update Neuralink

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ And we're back! Use this repo to share and keep track of software, tech, CS, PM,
 | [Epic](https://epic.avature.net/Careers/FolderDetail/Software-Developer-Intern---Summer-2024/23429) | Madison, WI | Software Developer Intern - Summer 2024 (No sponsorship available) |
 | [Ramp](https://boards.greenhouse.io/ramp) | New York, Miami, Remote | Software Engineer Intern--[Backend](https://boards.greenhouse.io/ramp/jobs/5083064002), [Frontend](https://boards.greenhouse.io/ramp/jobs/4820594002), [Android](https://boards.greenhouse.io/ramp/jobs/6726450002), [iOS](https://boards.greenhouse.io/ramp/jobs/5649105002) |
 | [Apple](https://jobs.apple.com/en-us/details/200480063/software-engineering-internships?team=STDNT) | United States | Software Engineering Internships |
-| [Neuralink](https://boards.greenhouse.io/neuralink/jobs/5285389003) | Fremont, CA ; Austin, TX| Software Engineering Internship, [Quality Assurance](https://boards.greenhouse.io/neuralink/jobs/5552854003) |
+| [Neuralink](https://boards.greenhouse.io/neuralink) | Fremont, CA <br/> Austin, TX | Software Engineer Intern at [Fremont, CA](https://boards.greenhouse.io/neuralink/jobs/5285389003) and [Austin, TX](https://boards.greenhouse.io/neuralink/jobs/5552197003) |
 | [Certik](https://jobs.lever.co/certik/095fdcff-99e8-408d-bb8a-e638e44d0b40) | United States | Platform Engineering Intern |
 | [MosaicML](https://boards.greenhouse.io/mosaicml/jobs/4133756004) | SF & San Diego, CA | Software Engineer Intern |
 


### PR DESCRIPTION
- Added links for location-specific SWE internships (Fremont, CA and Austin, TX)
- Removed QA internship
  - I looked over the [job description](https://boards.greenhouse.io/neuralink/jobs/5552854003) and I don't think it really qualifies as a tech internship:
    > The new hire is going to be a part of the Quality Systems Team assisting in implementing and managing design controls. The Quality Engineering Intern is responsible for assessing, establishing, and maintaining effective Design Control disciplines to ensure alignment of FDA Part 820.30 and ISO 13485 standards within the quality systems. Provide guidance and collaborate across departments to identify gaps and show ownership with a hands-on approach in driving solutions to address any identified Design Control (ISO-13485/CFR 820) gaps or remediation needs.