### PR TITLE
Fix Spotify and add No sponsorship in Palantir and Lumen

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,9 +64,8 @@ And we're back! Use this repo to share and keep track of software, tech, CS, PM,
 | [Bank of America](https://bankcampuscareers.tal.net/vx/lang-en-GB/mobile-0/brand-4/xf-91c0e92d74a1/candidate/so/pm/1/pl/1/opp/10165-Global-Technology-Summer-Analyst-Program-2024/en-GB) | Multiple US Locations | Global Technology Summer Analyst Program - 2024 | 
 | [Protivity](https://roberthalf.wd1.myworkdayjobs.com/en-US/ProtivitiNA/job/PHOENIX/Phoenix-Technology-Consulting-Intern---2024_JR-248209-2?Location_Country=bc33aa3152ec42d4995f4791a106ed09&Location_Region_State_Province=c7b20b0d4bc04711a00900569e9afabd) | Phoenix, AZ | Technology Consulting Intern - 2024 Summer Internship (No Sponsorship) |
 | [Mercedes-Benz](https://jobs.lever.co/MBRDNA/59ae463c-5d10-4bb6-9dfd-4e26c7d84a69) | Sunnyvale, CA | Data Products Intern |
-| [Palantir Technologies](https://www.palantir.com/careers/students/path/) | New York or Washington DC | Software Engineer Intern |
-| [Lumen Technologies](https://jobs.lumen.com/global/en/job/324980/Intern-Summer-2024-Program-Submit-Interest) | Remote, USA | Intern - Summer 2024 Program - Submit Interest |
-| [Spotify](https://jobs.lever.co/spotify/2319b24a-a5bf-48e8-9296-782b568966ed?fbclid=IwAR2WggT3iA-KiMY0gihNOtXh8_DrLOMssy9B5djuEeG0UqOy2R3ciYoobas) | New York | 2023 NYC Technology |
+| [Palantir Technologies](https://www.palantir.com/careers/students/path/) | New York or Washington DC | Software Engineer Intern (No sponsorship available) |
+| [Lumen Technologies](https://jobs.lumen.com/global/en/job/324980/Intern-Summer-2024-Program-Submit-Interest) | Remote, USA | Intern - Summer 2024 Program - Submit Interest (No sponsorship available) |
 
 <!-- Please leave a one line gap between this and the table -->
 [⬆️ Back to Top ⬆️](https://github.com/pittcsc/Summer2023-Internships#the-list-)

--- a/README.md
+++ b/README.md
@@ -64,9 +64,8 @@ And we're back! Use this repo to share and keep track of software, tech, CS, PM,
 | [Bank of America](https://bankcampuscareers.tal.net/vx/lang-en-GB/mobile-0/brand-4/xf-91c0e92d74a1/candidate/so/pm/1/pl/1/opp/10165-Global-Technology-Summer-Analyst-Program-2024/en-GB) | Multiple US Locations | Global Technology Summer Analyst Program - 2024 | 
 | [Protivity](https://roberthalf.wd1.myworkdayjobs.com/en-US/ProtivitiNA/job/PHOENIX/Phoenix-Technology-Consulting-Intern---2024_JR-248209-2?Location_Country=bc33aa3152ec42d4995f4791a106ed09&Location_Region_State_Province=c7b20b0d4bc04711a00900569e9afabd) | Phoenix, AZ | Technology Consulting Intern - 2024 Summer Internship (No Sponsorship) |
 | [Mercedes-Benz](https://jobs.lever.co/MBRDNA/59ae463c-5d10-4bb6-9dfd-4e26c7d84a69) | Sunnyvale, CA | Data Products Intern |
-
-| [Palantir Technologies](https://www.palantir.com/careers/students/path/) | New York or Washington DC | Software Engineer Intern |
-| [Lumen Technologies](https://jobs.lumen.com/global/en/job/324980/Intern-Summer-2024-Program-Submit-Interest) | Remote, USA | Intern - Summer 2024 Program - Submit Interest |
+| [Palantir Technologies](https://www.palantir.com/careers/students/path/) | New York or Washington DC | Software Engineer Intern (No sponsorship available) |
+| [Lumen Technologies](https://jobs.lumen.com/global/en/job/324980/Intern-Summer-2024-Program-Submit-Interest) | Remote, USA | Intern - Summer 2024 Program - Submit Interest (No sponsorship available) |
 
 
 <!-- Please leave a one line gap between this and the table -->

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ And we're back! Use this repo to share and keep track of software, tech, CS, PM,
 | [Mercedes-Benz](https://jobs.lever.co/MBRDNA/59ae463c-5d10-4bb6-9dfd-4e26c7d84a69) | Sunnyvale, CA | Data Products Intern |
 | [Palantir Technologies](https://www.palantir.com/careers/students/path/) | New York or Washington DC | Software Engineer Intern (No sponsorship available) |
 | [Lumen Technologies](https://jobs.lumen.com/global/en/job/324980/Intern-Summer-2024-Program-Submit-Interest) | Remote, USA | Intern - Summer 2024 Program - Submit Interest (No sponsorship available) |
+| [Spotify](https://jobs.lever.co/spotify/2319b24a-a5bf-48e8-9296-782b568966ed?fbclid=IwAR2WggT3iA-KiMY0gihNOtXh8_DrLOMssy9B5djuEeG0UqOy2R3ciYoobas) | New York | 2023 NYC Technology Fellowship Program |
 
 
 <!-- Please leave a one line gap between this and the table -->


### PR DESCRIPTION
[1). Remove Spotify:](https://github.com/pittcsc/Summer2024-Internships/commit/db607f1d1b1da068d308d38cffed9e6c87570dea) 

2023 Fellowship program not for 2024 Internship

2). add No Sponsorship available for Palantir and Lumen