### PR TITLE
Add interning.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ And we're back! Use this repo to share and keep track of software, tech, CS, PM,
 > **Note**:
 > This README file is for **2024 internships only**. For 2023 internships, please [click here](https://github.com/pittcsc/Summer2023-Internships/blob/dev/README-2023.md).
 
+Track your application progress at [PittCSC.com](https://www.pittcsc.com/)!
+
 [⬇️ Jump to bottom ⬇️](https://github.com/pittcsc/Summer2023-Internships#we-love-our-contributors-%EF%B8%8F%EF%B8%8F)
 <!-- Please leave a one line gap between this and the table -->
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ And we're back! Use this repo to share and keep track of software, tech, CS, PM,
 > **Note**:
 > This README file is for **2024 internships only**. For 2023 internships, please [click here](https://github.com/pittcsc/Summer2023-Internships/blob/dev/README-2023.md).
 
-Track your application progress at [PittCSC.com](https://www.pittcsc.com/)!
+Track your application progress at [interning.dev](https://www.interning.dev/)!
 
 [⬇️ Jump to bottom ⬇️](https://github.com/pittcsc/Summer2023-Internships#we-love-our-contributors-%EF%B8%8F%EF%B8%8F)
 <!-- Please leave a one line gap between this and the table -->


### PR DESCRIPTION
I love using PittCSC to find internships but sometimes it's hard to remember which ones you've already applied to. I made a simple open-source dashboard at [interning.dev](https://www.interning.dev/) to have easy access to the internships list and keep track of which ones I've already done, and I thought other people might find it helpful too!

Star/contribute here! ➡️ [github.com/csaye/interning.dev](https://github.com/csaye/interning.dev)