### PR TITLE
Add README for off-season internships

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 # Contributing to the Internship List
-Thank you for your interest in contributing to the Pitt CSC internship list! 
+Thank you for your interest in contributing to the Pitt CSC internship list!
 
 Below, you'll find the guidelines for our repository. Chances are, you can probably just look at how other internships are formatted and follow it. If you have any questions, please create an [issue](https://github.com/pittcsc/Summer2024-Internships/issues/new) here.
 
@@ -7,23 +7,28 @@ Finally, while these are guidelines, **don't** stress about making your submissi
 
 ## Finding an Internship to Add
 We ask that the internships that you add meet some requirements. Specifically, your internship must
-- be in one of the following categories: 
+- be in one of the following categories:
     - software/computer engineering,
     - computer/data science,
     - product manager,
     - quant, and
     - any other tech-related internships.
-- be for **summer 2023** or **summer 2024**. We will *not* accept internships for a different term.
 - be located in the United States, Canada, or remote.
-- not already exist in the internship list, and must not be pending review [here](https://github.com/pittcsc/Summer2024-Internships/pulls). 
-    - Note that we have two separate READMEs; one for [Summer 2023 internships](https://github.com/pittcsc/Summer2024-Internships/blob/dev/README-2023.md) and one for [Summer 2024 internships](https://github.com/pittcsc/Summer2024-Internships/blob/dev/README.md). Be sure you're contributing to the correct one.
+- not already exist in the internship list, and must not be pending review [here](https://github.com/pittcsc/Summer2024-Internships/pulls).
+
+Note that we have multiple READMEs for different internship terms:
+- [Summer 2024 internships](https://github.com/pittcsc/Summer2024-Internships/blob/dev/README.md)
+- [Summer 2023 internships](https://github.com/pittcsc/Summer2024-Internships/blob/dev/README-2023.md)
+- [Off-season internships](https://github.com/pittcsc/Summer2024-Internships/blob/dev/README-Off-Season.md)
+
+Be sure you're contributing to the correct one.
 
 Make sure to have the following information ready:
 - The name of the position.
 - The location of the position.
-- A link to the job *description* page. The link should direct the user to the page, **not** a third party website or general careers page.
-- The immigration requirements of the position
-    - An easy way to check is to search for keywords like `visa` or `sponsorship`.
+- A link to the job *description* page. The link should direct the user to the page for the position itself, **not** a third-party website or general careers page.
+- The citizenship/immigration requirements of the position
+    - An easy way to check is to search for keywords like `citizen`, `visa`, or `sponsorship`.
 
 ## Adding an Internship
 Cool! You're ready to add an internship to the list.
@@ -44,24 +49,24 @@ Depending on the number of internships you plan on adding, what you're essential
 
     <details>
     <summary>Examples</summary>
-    <br> 
+    <br>
 
     In Markdown, this might look like one of the following rows:
 
     ```md
     | [Target](https://jobs.target.com/job/-/-/1118/34525104848) | Brooklyn Park, MN | Software Engineering Intern - Hybrid (Starting June 2023) |
     | [ByteDance](https://jobs.bytedance.com/en/position/7138261141784611103/detail?spread=BSPP2KS) | Mountain View, CA | Software Engineer Intern |
-    | [SpaceX](https://boards.greenhouse.io/spacex/jobs/6366187002?gh_jid=6366187002) | Multiple| 2023 Summer Intern - Software Engineer (US Citizens Only) | 
+    | [SpaceX](https://boards.greenhouse.io/spacex/jobs/6366187002?gh_jid=6366187002) | Multiple | 2023 Summer Intern - Software Engineer (US Citizens Only) |
     ```
 
     When rendered, it will look like:
 
-    | Name | Location |  Notes |
-    | ---- | -------- | ------ |
+    | Name | Location | Notes |
+    | ---- | -------- | ----- |
     | [Target](https://jobs.target.com/job/-/-/1118/34525104848) | Brooklyn Park, MN | Software Engineering Intern - Hybrid (Starting June 2023) |
     | [ByteDance](https://jobs.bytedance.com/en/position/7138261141784611103/detail?spread=BSPP2KS) | Mountain View, CA | Software Engineer Intern |
-    | [SpaceX](https://boards.greenhouse.io/spacex/jobs/6366187002?gh_jid=6366187002) | Multiple| 2023 Summer Intern - Software Engineer (US Citizens Only) | 
-    
+    | [SpaceX](https://boards.greenhouse.io/spacex/jobs/6366187002?gh_jid=6366187002) | Multiple | 2023 Summer Intern - Software Engineer (US Citizens Only) |
+
     </details>
 
 - adding multiple **unique** internships for a company (e.g., the company has a SWE and PM internship):
@@ -71,7 +76,7 @@ Depending on the number of internships you plan on adding, what you're essential
 
     <details>
     <summary>Examples</summary>
-    <br> 
+    <br>
 
     In Markdown, this might look like one of the following rows:
 
@@ -83,8 +88,8 @@ Depending on the number of internships you plan on adding, what you're essential
 
     When rendered, it will look like:
 
-    | Name | Location |  Notes |
-    | ---- | -------- | ------ |
+    | Name | Location | Notes |
+    | ---- | -------- | ----- |
     | Adobe | Various | [Software Engineer Intern](https://careers.adobe.com/us/en/job/R131626/2023-Intern-Software-Engineer), [Software Engineer (Mobile Development) Intern](https://careers.adobe.com/us/en/job/R131674/2023-Intern-Software-Engineer-Mobile-Development) |
     | Delta | Atlanta, GA, Minneapolis St. Paul, MN | [Software Engineer Intern](https://delta.avature.net/careers/JobDetail/Intern-Software-Engineering-Summer-2023/17376), [Data Science Intern](https://delta.avature.net/careers/JobDetail/Intern-IT-Operations-Research-Data-Science-Summer-2023/17381), [Data Analytics Intern](https://delta.avature.net/careers/JobDetail/Intern-Revenue-Technology-Data-Analytics-Summer-2023/17650) |
     | Raytheon | Varies by Role | [UP 2023 Software Engineer Internships](https://careers.rtx.com/global/en/job/RAYTGLOBAL01567022EXTERNALENGLOBAL/UP-2023-Software-Engineer-Internships), [2023 Software Engineer Summer Intern](https://careers.rtx.com/global/en/job/RAYTGLOBAL01569607EXTERNALENGLOBAL/2023-Software-Engineer-Summer-Intern) (US Citizenship Required for Both) |
@@ -100,7 +105,7 @@ Depending on the number of internships you plan on adding, what you're essential
 
         <details>
         <summary>Examples</summary>
-        <br> 
+        <br>
 
         In Markdown, this might look like one of the following rows:
 
@@ -109,8 +114,8 @@ Depending on the number of internships you plan on adding, what you're essential
         ```
 
         When rendered, it will look like:
-        | Name | Location |  Notes |
-        | ---- | -------- | ------ |
+        | Name | Location | Notes |
+        | ---- | -------- | ----- |
         | [Garmin](https://careers.garmin.com/careers-home/jobs?tags3=Intern&page=1) | Various | Software Engineer Intern (Summer 2023): [Tulsa, OK](https://careers.garmin.com/careers-home/jobs/9345?lang=en-us), [Scottsdale, AZ](https://careers.garmin.com/careers-home/jobs/9267?lang=en-us), [Chandler, AZ](https://careers.garmin.com/careers-home/jobs/9266?lang=en-us), [Boulder, CO](https://careers.garmin.com/careers-home/jobs/9220?lang=en-us), [Tucson, AZ](https://careers.garmin.com/careers-home/jobs/9219?lang=en-us), [Cary, NC](https://careers.garmin.com/careers-home/jobs/9243?lang=en-us) |
 
         </details>
@@ -123,7 +128,7 @@ Depending on the number of internships you plan on adding, what you're essential
 
         <details>
         <summary>Examples</summary>
-        <br> 
+        <br>
 
         In Markdown, this might look like one of the following rows:
 
@@ -133,14 +138,14 @@ Depending on the number of internships you plan on adding, what you're essential
         ```
 
         When rendered, it will look like:
-        | Name | Location |  Notes |
-        | ---- | -------- | ------ |
+        | Name | Location | Notes |
+        | ---- | -------- | ----- |
         | [Northrop Grumman](https://ngc.wd1.myworkdayjobs.com/en-US/Northrop_Grumman_External_Site/details/College-Intern-Administrative---Documentation_R10064554-1?q=software%20engineer&workerSubType=a111b0a898f10129e4db58f2e700d97a) | Various | Software Engineer Intern (US Citizenship Required) |
         | [Keysight Technologies](https://jobs.keysight.com/go/Students/3065700/?q=&q2=&alertId=&title=software&location=US&shifttype=intern&department=)| Santa Rosa, CA | Various Positions |
 
         </details>
 
-If you have internships for multiple companies, repeat the process above. 
+If you have internships for multiple companies, repeat the process above.
 
 Once you have the rows, append them to the *bottom* of the table. So, for example, if you want to add the rows
 ```
@@ -151,7 +156,7 @@ and the table in the README currently has
 ```
 | 1 | 1 | 1 |
 | 2 | 2 | 2 |
-| 3 | 3 | 3 | 
+| 3 | 3 | 3 |
 | 4 | 4 | 4 |
 
 <!-- Please leave a one line gap between this and the table -->
@@ -161,7 +166,7 @@ add the rows like so:
 ```
 | 1 | 1 | 1 |
 | 2 | 2 | 2 |
-| 3 | 3 | 3 | 
+| 3 | 3 | 3 |
 | 4 | 4 | 4 |
 | A | A | A |
 | B | B | B |
@@ -172,13 +177,13 @@ add the rows like so:
 ### If the Company *Does* Exist
 If the company already exists in the table, make sure the internship you're trying to add isn't already there!
 
-If it isn't, then simply edit the existing row based on the specifications described above (under "If the Company Doesn't Exist"). **Please move the row to the bottom of the internship list so viewers see the updated entry.** 
+If it isn't, then simply edit the existing row based on the specifications described above (under "If the Company Doesn't Exist"). **Please move the row to the bottom of the internship list so viewers see the updated entry.**
 
 For example, if the README table looks like
 ```
 | 1 | 1 | 1 |
 | 2 | 2 | 2 |
-| 3 | 3 | 3 | 
+| 3 | 3 | 3 |
 | 4 | 4 | 4 |
 
 <!-- Please leave a one line gap between this and the table -->
@@ -187,7 +192,7 @@ For example, if the README table looks like
 and you wanted to edit the second row (the one with the `2`'s) to say `| 2 | 2 | 2, B |`, then you would end up with:
 ```
 | 1 | 1 | 1 |
-| 3 | 3 | 3 | 
+| 3 | 3 | 3 |
 | 4 | 4 | 4 |
 | 2 | 2 | 2, B |
 
@@ -196,7 +201,7 @@ and you wanted to edit the second row (the one with the `2`'s) to say `| 2 | 2 |
 ```
 
 ## Removing an Internship
-Suppose you come across an outdated entry or the posting is now closed. 
+Suppose you come across an outdated entry or the posting is now closed.
 
 - If a company only has one internship offering, change the posting's formatting to:
     ```md
@@ -207,15 +212,15 @@ Suppose you come across an outdated entry or the posting is now closed.
 
     <details>
     <summary>Examples</summary>
-    <br> 
+    <br>
 
-    Suppose that the Target closed their internship. Initially, the row might look like this:
+    Suppose that Target closed their internship. Initially, the row might have looked like this:
 
     ```md
     | [Target](https://jobs.target.com/job/-/-/1118/34525104848) | Brooklyn Park, MN | Software Engineering Intern - Hybrid (Starting June 2023) |
     ```
 
-    When rendered, it will look like:
+    When rendered, it looked like:
 
     | Name | Location |  Notes |
     | ---- | -------- | ------ |
@@ -241,4 +246,4 @@ Suppose you come across an outdated entry or the posting is now closed.
 There aren't any specific guidelines here. As long as it is consistent with what we have above, then it should be fine.
 
 ## Done with Changes?
-Once you're done with your changes, please create a **pull request** (for more information, click [here](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request)). We will review your pull request and suggest changes if necessary. 
+Once you're done with your changes, please create a **pull request** (for more information, click [here](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request)). We will review your pull request and suggest changes if necessary.

--- a/README-2023.md
+++ b/README-2023.md
@@ -1,11 +1,11 @@
 # Summer 2023 Tech Internships by Pitt CSC and Simplify
-And we're back! Use this repo to share and keep track of software, tech, CS, PM, quant internships for Summer 2023. List maintained by [the Pitt Computer Science Club](https://pittcsc.org/) and [Simplify](https://simplify.jobs/)!
+And we're back! Use this repo to share and keep track of software, tech, CS, PM, quant internships for **Summer 2023**. List maintained by the [Pitt Computer Science Club](https://pittcsc.org/) and [Simplify](https://simplify.jobs/)!
 
 :warning: **This repository is only for internships/co-ops in the United States, Canada or for Remote positions :earth_americas:.**
 
 🧠 For tips on the internship process check out the [Zero to Offer](https://www.pittcs.wiki/zero-to-offer) 🧠
 
-🙏 **Contribute by submitting a [pull request](https://github.com/susam/gitpr#create-pull-request)! See the contribution guidelines [here](https://github.com/pittcsc/Summer2023-Internships/blob/dev/CONTRIBUTING.md)!** 🙏
+🙏 **Contribute by submitting a [pull request](https://github.com/susam/gitpr#create-pull-request)! See the contribution guidelines [here](https://github.com/pittcsc/Summer2024-Internships/blob/dev/CONTRIBUTING.md)!** 🙏
 
 ---
 <div align="center">
@@ -16,7 +16,9 @@ And we're back! Use this repo to share and keep track of software, tech, CS, PM,
 			Autofill all your applications in a single click.
 			<br>
 			<div>
-				<a href="https://simplify.jobs/?utm_source=pittcsc&utm_medium=internships_repo"><img src="https://res.cloudinary.com/dpeo4xcnc/image/upload/v1636594918/simplify_pittcsc.png" width="450" alt="Simplify" ></a>
+				<a href="https://simplify.jobs/?utm_source=pittcsc&utm_medium=internships_repo">
+          <img src="https://res.cloudinary.com/dpeo4xcnc/image/upload/v1636594918/simplify_pittcsc.png" width="450" alt="Simplify">
+        </a>
 			</div>
 		</a>
 		<sub><i>Stop manually re-entering your information. Simplify’s extension helps you autofill internship applications on millions of sites.</i></sub>
@@ -27,9 +29,9 @@ And we're back! Use this repo to share and keep track of software, tech, CS, PM,
 
 ## The List 🚴🏔
 > **Note**:
-> This README file is for **2023 internships only**. For 2024 internships, please [click here](https://github.com/pittcsc/Summer2023-Internships/blob/dev/README-2024.md).
+> This README file is for **Summer 2023 internships only**. For Summer 2024 internships, please [click here](https://github.com/pittcsc/Summer2024-Internships/blob/dev/README-2024.md).
 
-[⬇️ Jump to bottom ⬇️](https://github.com/pittcsc/Summer2023-Internships#we-love-our-contributors-%EF%B8%8F%EF%B8%8F)
+[⬇️ Jump to bottom ⬇️](#we-love-our-contributors-❤️❤️)
 <!-- Please leave a one line gap between this and the table -->
 
 | Name | Location | Notes |
@@ -672,11 +674,11 @@ And we're back! Use this repo to share and keep track of software, tech, CS, PM,
 | Spotify | New York, NY <br/> Remote (Americas) | **🔒 Closed 🔒** 2023 NYC Technology Fellowship Program <br/> **🔒 Closed 🔒** Backend Engineer Intern |
 
 <!-- Please leave a one line gap between this and the table -->
-[⬆️ Back to Top ⬆️](https://github.com/pittcsc/Summer2023-Internships#the-list-)
+[⬆️ Back to Top ⬆️](#the-list-🚴🏔)
 
 ## We love our contributors ❤️❤️
 Make a [pull request](https://github.com/susam/gitpr#create-pull-request) to help contribute.
-<a href="https://github.com/pittcsc/Summer2023-Internships/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=pittcsc/Summer2023-Internships&columns=24&max=480" />
+<a href="https://github.com/pittcsc/Summer2024-Internships/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=pittcsc/Summer2024-Internships&columns=24&max=480"/>
 </a>
 *Made with [contrib.rocks](https://contrib.rocks).*

--- a/README-2023.md
+++ b/README-2023.md
@@ -31,7 +31,7 @@ And we're back! Use this repo to share and keep track of software, tech, CS, PM,
 > **Note**:
 > This README file is for **Summer 2023 internships only**. For Summer 2024 internships, please [click here](https://github.com/pittcsc/Summer2024-Internships/blob/dev/README-2024.md).
 
-[⬇️ Jump to bottom ⬇️](#we-love-our-contributors-❤️❤️)
+[⬇️ Jump to bottom ⬇️](https://github.com/pittcsc/Summer2024-Internships/blob/dev/README-2023.md#we-love-our-contributors-%EF%B8%8F%EF%B8%8F)
 <!-- Please leave a one line gap between this and the table -->
 
 | Name | Location | Notes |
@@ -674,7 +674,7 @@ And we're back! Use this repo to share and keep track of software, tech, CS, PM,
 | Spotify | New York, NY <br/> Remote (Americas) | **🔒 Closed 🔒** 2023 NYC Technology Fellowship Program <br/> **🔒 Closed 🔒** Backend Engineer Intern |
 
 <!-- Please leave a one line gap between this and the table -->
-[⬆️ Back to Top ⬆️](#the-list-🚴🏔)
+[⬆️ Back to Top ⬆️](https://github.com/pittcsc/Summer2024-Internships/blob/dev/README-2023.md#the-list-)
 
 ## We love our contributors ❤️❤️
 Make a [pull request](https://github.com/susam/gitpr#create-pull-request) to help contribute.

--- a/README-Off-Season.md
+++ b/README-Off-Season.md
@@ -1,0 +1,57 @@
+# Off-Season Tech Internships by Pitt CSC & Simplify
+And we're back! Use this repo to share and keep track of software, tech, CS, PM, quant internships for **Fall 2023, Winter 2024, or Spring 2024**. List maintained by [the Pitt Computer Science Club](https://pittcsc.org/) and [Simplify](https://simplify.jobs/)!
+
+:warning: **This repository is only for internships/co-ops in the United States, Canada or for Remote positions :earth_americas:.**
+
+🧠 For tips on the internship process check out [Zero to Offer](https://www.pittcs.wiki/zero-to-offer) 🧠
+
+🙏 **Contribute by submitting a [pull request](https://github.com/susam/gitpr#create-pull-request)! See the contribution guidelines [here](https://github.com/pittcsc/Summer2024-Internships/blob/dev/CONTRIBUTING.md)!** 🙏
+
+---
+<div align="center">
+  <p>
+    <a href="https://simplify.jobs/?utm_source=pittcsc&utm_medium=internships_repo">
+      <b>Applying to internships?</b>
+      <br>
+      Autofill all your applications in a single click.
+      <br>
+      <div>
+        <a href="https://simplify.jobs/?utm_source=pittcsc&utm_medium=internships_repo">
+          <img src="https://res.cloudinary.com/dpeo4xcnc/image/upload/v1636594918/simplify_pittcsc.png" width="450" alt="Simplify">
+        </a>
+      </div>
+    </a>
+    <sub><i>Stop manually re-entering your information. Simplify’s extension helps you autofill internship applications on millions of sites.</i></sub>
+  </p>
+</div>
+
+<div align="center">
+  <h3>
+    Thanks for a great three years 💖💖
+  </h3>
+  <p>
+    <img src="https://api.star-history.com/svg?repos=pittcsc/Summer2024-Internships&type=Date" width="500" alt="Star History">
+  </p>
+</div>
+
+---
+
+## The List 🚴🏔
+> **Note**:
+> This README file is for **non-summer internships only**. For summer internships, please see the [Summer 2023 README](https://github.com/pittcsc/Summer2024-Internships/blob/dev/README-2023.md) or the [Summer 2024 README](https://github.com/pittcsc/Summer2024-Internships/blob/dev/README.md).
+
+[⬇️ Jump to bottom ⬇️](#we-love-our-contributors-❤️❤️)
+<!-- Please leave a one line gap between this and the table -->
+
+| Name | Location | Notes |
+| ---- | -------- | ----- |
+
+<!-- Please leave a one line gap between this and the table -->
+[⬆️ Back to Top ⬆️](#the-list-🚴🏔)
+
+## We love our contributors ❤️❤️
+Make a [pull request](https://github.com/susam/gitpr#create-pull-request) to help contribute.
+<a href="https://github.com/pittcsc/Summer2024-Internships/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=pittcsc/Summer2024-Internships&columns=24&max=480"/>
+</a>
+*Made with [contrib.rocks](https://contrib.rocks).*

--- a/README-Off-Season.md
+++ b/README-Off-Season.md
@@ -40,14 +40,14 @@ And we're back! Use this repo to share and keep track of software, tech, CS, PM,
 > **Note**:
 > This README file is for **non-summer internships only**. For summer internships, please see the [Summer 2023 README](https://github.com/pittcsc/Summer2024-Internships/blob/dev/README-2023.md) or the [Summer 2024 README](https://github.com/pittcsc/Summer2024-Internships/blob/dev/README.md).
 
-[⬇️ Jump to bottom ⬇️](#we-love-our-contributors-❤️❤️)
+[⬇️ Jump to bottom ⬇️](https://github.com/pittcsc/Summer2024-Internships/blob/dev/README-Off-Season.md#we-love-our-contributors-%EF%B8%8F%EF%B8%8F)
 <!-- Please leave a one line gap between this and the table -->
 
 | Name | Location | Notes |
 | ---- | -------- | ----- |
 
 <!-- Please leave a one line gap between this and the table -->
-[⬆️ Back to Top ⬆️](#the-list-🚴🏔)
+[⬆️ Back to Top ⬆️](https://github.com/pittcsc/Summer2024-Internships/blob/dev/README-Off-Season.md#the-list-)
 
 ## We love our contributors ❤️❤️
 Make a [pull request](https://github.com/susam/gitpr#create-pull-request) to help contribute.

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ And we're back! Use this repo to share and keep track of software, tech, CS, PM,
 > **Note**:
 > This README file is for **Summer 2024 internships only**. For Summer 2023 internships, please [click here](https://github.com/pittcsc/Summer2024-Internships/blob/dev/README-2023.md).
 
-[⬇️ Jump to bottom ⬇️](#we-love-our-contributors-❤️❤️)
+[⬇️ Jump to bottom ⬇️](https://github.com/pittcsc/Summer2024-Internships#we-love-our-contributors-%EF%B8%8F%EF%B8%8F)
 <!-- Please leave a one line gap between this and the table -->
 
 | Name | Location | Notes |
@@ -73,7 +73,7 @@ And we're back! Use this repo to share and keep track of software, tech, CS, PM,
 | [Marotta Controls](https://marotta.com/job-openings/?gnk=job&gni=8a7883ac879c5eca0187ef4d715d4fd8&lang=en) | Parsippany, NJ | Software Engineering Intern - (Summer 2024) (U.S citizens only)|
 
 <!-- Please leave a one line gap between this and the table -->
-[⬆️ Back to Top ⬆️](#the-list-🚴🏔)
+[⬆️ Back to Top ⬆️](https://github.com/pittcsc/Summer2024-Internships#the-list-)
 
 ## We love our contributors ❤️❤️
 Make a [pull request](https://github.com/susam/gitpr#create-pull-request) to help contribute.

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Summer 2024 Tech Internships by Pitt CSC & Simplify
-And we're back! Use this repo to share and keep track of software, tech, CS, PM, quant internships for **Summer 2024**. List maintained by [the Pitt Computer Science Club](https://pittcsc.org/)!
+And we're back! Use this repo to share and keep track of software, tech, CS, PM, quant internships for **Summer 2024**. List maintained by the [Pitt Computer Science Club](https://pittcsc.org/) and [Simplify](https://simplify.jobs/)!
 
 :warning: **This repository is only for internships/co-ops in the United States, Canada or for Remote positions :earth_americas:.**
 
 🧠 For tips on the internship process check out [Zero to Offer](https://www.pittcs.wiki/zero-to-offer) 🧠
 
-🙏 **Contribute by submitting a [pull request](https://github.com/susam/gitpr#create-pull-request)! See the contribution guidelines [here](https://github.com/pittcsc/Summer2023-Internships/blob/dev/CONTRIBUTING.md)!** 🙏
+🙏 **Contribute by submitting a [pull request](https://github.com/susam/gitpr#create-pull-request)! See the contribution guidelines [here](https://github.com/pittcsc/Summer2024-Internships/blob/dev/CONTRIBUTING.md)!** 🙏
 
 ---
 <div align="center">
@@ -16,7 +16,9 @@ And we're back! Use this repo to share and keep track of software, tech, CS, PM,
       Autofill all your applications in a single click.
       <br>
       <div>
-        <a href="https://simplify.jobs/?utm_source=pittcsc&utm_medium=internships_repo"><img src="https://res.cloudinary.com/dpeo4xcnc/image/upload/v1636594918/simplify_pittcsc.png" width="450" alt="Simplify" ></a>
+        <a href="https://simplify.jobs/?utm_source=pittcsc&utm_medium=internships_repo">
+          <img src="https://res.cloudinary.com/dpeo4xcnc/image/upload/v1636594918/simplify_pittcsc.png" width="450" alt="Simplify">
+        </a>
       </div>
     </a>
     <sub><i>Stop manually re-entering your information. Simplify’s extension helps you autofill internship applications on millions of sites.</i></sub>
@@ -28,7 +30,7 @@ And we're back! Use this repo to share and keep track of software, tech, CS, PM,
     Thanks for a great three years 💖💖
   </h3>
   <p>
-    <img src="https://api.star-history.com/svg?repos=pittcsc/Summer2024-Internships&type=Date" width="500"  alt="Star History">
+    <img src="https://api.star-history.com/svg?repos=pittcsc/Summer2024-Internships&type=Date" width="500" alt="Star History">
   </p>
 </div>
 
@@ -36,9 +38,9 @@ And we're back! Use this repo to share and keep track of software, tech, CS, PM,
 
 ## The List 🚴🏔
 > **Note**:
-> This README file is for **2024 internships only**. For 2023 internships, please [click here](https://github.com/pittcsc/Summer2023-Internships/blob/dev/README-2023.md).
+> This README file is for **Summer 2024 internships only**. For Summer 2023 internships, please [click here](https://github.com/pittcsc/Summer2024-Internships/blob/dev/README-2023.md).
 
-[⬇️ Jump to bottom ⬇️](https://github.com/pittcsc/Summer2023-Internships#we-love-our-contributors-%EF%B8%8F%EF%B8%8F)
+[⬇️ Jump to bottom ⬇️](#we-love-our-contributors-❤️❤️)
 <!-- Please leave a one line gap between this and the table -->
 
 | Name | Location | Notes |
@@ -61,7 +63,7 @@ And we're back! Use this repo to share and keep track of software, tech, CS, PM,
 | [Capstone Investment Advisors](https://www.capstoneco.com/careers/2024-summer-internship-software-engineer-nyc/) | New York, NY | 2024 Summer Internship – Software Engineer |
 | D.E. Shaw | New York, NY | [Software Development Intern (New York) - Summer 2024](https://www.deshaw.com/careers/software-developer-intern-new-york-summer-2024-4803) <br/> [Systems: Technical Program Manager Intern (New York) – Summer 2024](https://www.deshaw.com/careers/systems-technical-program-manager-intern-new-york-summer-2024-4786) |
 | Google | Multiple US Locations | **🔒 Closed 🔒** <br/> Software Engineering Intern (BS) <br/> Software Engineering Intern (MS) |
-| [Bank of America](https://bankcampuscareers.tal.net/vx/lang-en-GB/mobile-0/brand-4/xf-91c0e92d74a1/candidate/so/pm/1/pl/1/opp/10165-Global-Technology-Summer-Analyst-Program-2024/en-GB) | Multiple US Locations | Global Technology Summer Analyst Program - 2024 | 
+| [Bank of America](https://bankcampuscareers.tal.net/vx/lang-en-GB/mobile-0/brand-4/xf-91c0e92d74a1/candidate/so/pm/1/pl/1/opp/10165-Global-Technology-Summer-Analyst-Program-2024/en-GB) | Multiple US Locations | Global Technology Summer Analyst Program - 2024 |
 | [Protivity](https://roberthalf.wd1.myworkdayjobs.com/en-US/ProtivitiNA/job/PHOENIX/Phoenix-Technology-Consulting-Intern---2024_JR-248209-2?Location_Country=bc33aa3152ec42d4995f4791a106ed09&Location_Region_State_Province=c7b20b0d4bc04711a00900569e9afabd) | Phoenix, AZ | Technology Consulting Intern - 2024 Summer Internship (No Sponsorship) |
 | [Mercedes-Benz](https://jobs.lever.co/MBRDNA/59ae463c-5d10-4bb6-9dfd-4e26c7d84a69) | Sunnyvale, CA | Data Products Intern |
 | [Palantir Technologies](https://www.palantir.com/careers/students/path/) | New York, NY or Washington, DC | Palantir Path Intern (must be enrolled in a U.S. bachelor's program) |
@@ -71,11 +73,11 @@ And we're back! Use this repo to share and keep track of software, tech, CS, PM,
 | [Marotta Controls](https://marotta.com/job-openings/?gnk=job&gni=8a7883ac879c5eca0187ef4d715d4fd8&lang=en) | Parsippany, NJ | Software Engineering Intern - (Summer 2024) (U.S citizens only)|
 
 <!-- Please leave a one line gap between this and the table -->
-[⬆️ Back to Top ⬆️](https://github.com/pittcsc/Summer2023-Internships#the-list-)
+[⬆️ Back to Top ⬆️](#the-list-🚴🏔)
 
 ## We love our contributors ❤️❤️
 Make a [pull request](https://github.com/susam/gitpr#create-pull-request) to help contribute.
-<a href="https://github.com/pittcsc/Summer2023-Internships/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=pittcsc/Summer2023-Internships&columns=24&max=480" />
+<a href="https://github.com/pittcsc/Summer2024-Internships/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=pittcsc/Summer2024-Internships&columns=24&max=480" />
 </a>
 *Made with [contrib.rocks](https://contrib.rocks).*


### PR DESCRIPTION
Fixes #1910

Recreates @ewang2002's from #1917 for an off-season internship README, continuing from the discussion in #1962. The main difference is that I kept the images from the main README, as @FishOfPitt116 has requested that the format stay the same.