### PR TITLE
Add Old READMEs

### DIFF
--- a/archived/README-2021.md
+++ b/archived/README-2021.md
@@ -1,0 +1,878 @@
+# Summer 2021 Internships ☀️👩‍💻
+**In the coming days/weeks we will be transitioning this repository to a Summer 2022 one. If you have any ideas on how we can improve the repo, please let us know by creating an issue**
+
+Use this repo to share and keep track of any tech-related internships. For a [Google Sheet 📝 version of this repo (that remains in sync with this table) click here](https://docs.google.com/spreadsheets/d/1bJq7YQV19TWyzPCBeQi5P4uOm8uiAAm2AHCnVNGRIDg/edit#gid=0)! For more tips on the internship process check out the [Zero to Offer 📈 program here](https://www.pittcs.wiki/zero-to-offer).
+
+🎓 Check out our New Grad repo [here](https://github.com/Pitt-CSC/NewGrad-2021).
+
+🤗 **Contribute by submitting a [pull request](https://github.com/susam/gitpr#create-pull-request) or [filling out this form](https://bit.ly/3d5O76c)!**  🤗
+
+## The List 👔
+
+| Name  |  Location |  Notes |
+|---|---|-------------|
+|[SAP](https://jobs.sap.com/search/?createNewAlert=false&q=&locationsearch=&optionsFacetsDD_department=&optionsFacetsDD_customfield3=Student&optionsFacetsDD_country=US) | Various | |
+|[Akuna Capital](https://akunacapital.com/careers?&experience=intern&department=&location=&search_term=#careers)| Boston, Chicago, International Location | |
+|[Apple](https://jobs.apple.com/en-us/search?location=united-states-USA&team=internships-STDNT-INTRN)| Cupertino, CA| |
+|[BlackRock](https://blackrock.tal.net/vx/lang-en-GB/mobile-0/brand-3/xf-fb4e3bf3ac65/candidate/so/pm/1/pl/1/opp/3907-Summer-Analyst-Program-Americas/en-GB) | New York, NY|  |
+|[Bridgewater Associate](https://boards.greenhouse.io/bridgewater89/jobs/4076389002)| Westport, CT |  |
+|[ByteDance/TikTok](https://careers.tiktok.com/position?project=6854152751179303182&type=3&current=1&limit=100)| Remote | Remote allowed in CA/WA/IL/NY/FL/DC/VA/TN/TX/MI. Referral code: VC7FSRM |
+|[Citadel](https://www.citadel.com/careers/open-positions/positions-for-students/)| Chicago, New York, other global locations | |
+|Cisco| San Jose, Seattle, RTP, San Francisco, Richardson, Austin, Fulton, Cambridge, Boxborough, Richfield, Alpharetta | **Closed** Network Support Engineer, Site Reliability Engineer, Software Engineer Intern positions are available. Able to legally live and work in the country for which you’re applying, without visa support or sponsorship. |
+|Credit Suisse | New York, NY | **Closed**|
+|[D.E. Shaw](https://www.deshaw.com/careers/software-developer-intern-new-york-4018) | New York | |
+|[DRW](https://drw.com/careers/listings/?language=English&category=Campus&location=Chicago) |  Chicago | Software Development, Quant Trader, Quant Research Intern|
+|[Facebook](https://www.facebook.com/careers/jobs/654496918442526/)| Various | |
+|[Five Rings Capital](https://fiverings.com/apply/)| New York | Quant Trading, Quant Research, Software Development|
+|[Goldman Sachs](https://www.goldmansachs.com/careers/students/programs/americas/summer-analyst-program.html)| Various  ||
+|[Hudson River Trading](https://www.hudsonrivertrading.com/careers/) | New York, Chicago | Software Engineering, Mid-Frequency Algo|
+|[IMC Trading](https://careers.imc.com/us/en/c/internships-jobs)| Chicago | Hardware Engineering, Software Engineering, Quant Trading intern |
+|Morgan Stanley | New York| **Closed** |
+|[Pimco](https://careers.pimco.com/careers/SearchJobs/?listFilterMode=1&794=%5B%7B%22%24JSNType%22%3A%22dataset_Option%22%2C%22value%22%3A%7B%22id%22%3A1262%2C%22name%22%3Anull%7D%7D%5D&794_format=659)| Austin, Newport Beach| Software Engineering, Data Science |
+|[Tower Research](https://www.tower-research.com/open-positions/?gh_jid=2238182&gh_src=PittCSC) | Chicago, New York | |
+|[Jane Street](https://www.janestreet.com/join-jane-street/internships/)| New York | |
+|PDT Partners| New York | **Closed** |
+|Point72 | New York | **Closed** Analyst Academy|
+|Bracebridge Capital|Boston|Closed|
+|[Jump Trading](https://www.jumptrading.com/jobs.html)| Chicago |[Tech Ops](https://www.jumptrading.com/apply.html?gh_jid=1848604), [Production](https://www.jumptrading.com/apply.html?gh_jid=2297249), [FPGA](https://www.jumptrading.com/apply.html?gh_jid=2406074) and other positions available |
+|BNP Paribas| New York | **Closed** |
+|[Belvedere Trading](https://belvederetrading.applicantstack.com/x/detail/a2sa4x0tugum/aa1b?noia=1)| Chicago | |
+|RBC| Jersey City | **Closed** |
+|[Arrowstreet Capital](https://arrowstreetcapital.wd5.myworkdayjobs.com/en-US/Arrowstreet/jobs) | Boston | Quantitative Developer, Data Science, Research Systems, Research Associate |
+|[Paypal](https://jobsearch.paypal-corp.com/en-US/search?keywords=%22software%20engineer%20intern%22&location=&facetcountry=us) | Various | |
+|Discover| Houston | **Closed** |
+|Prudential| Newark, NJ | **Closed** |
+|Neeva| Mountain View, CA | **Closed** |
+|Squarepoint Capital | NY, London, Singapore, Montreal | **Closed** |
+|[Cambly](https://jobs.lever.co/cambly/96ea4732-5f6a-4027-9695-20cbb650bede/apply) | San Francisco | |
+|Nuro | Mountain View | Closed Have more internships here  |
+|[Two Sigma](https://careers.twosigma.com/careers/JobDetail?jobId=6666&source=PittCSC)| New York NY | |
+|Zapata Computing | Boston, MA| **Closed**|
+|National Security Agency | Fort Meade, MD | **Closed** |
+|[MealMe](https://www.mealme.ai/careers) |  | Also has Fall internships |
+|[Vanguard](https://www.vanguardjobs.com/job-search-results/?keyword=%2211050430%22%20OR%20%2211050428%22%20OR%20%2211050431%22%20OR%20%2211050429%22) | Malvern, PA or Charlotte, NC | See issues [25](https://github.com/Pitt-CSC/Summer2021-Internships/issues/25) and [30](https://github.com/Pitt-CSC/Summer2021-Internships/issues/30)|
+|[Abbvie](https://careers.abbvie.com/abbvie/jobs/2005191?lang=en-us&previousLocale=en-US) | Chicago | |
+|Optiver| Chicago | **Closed** |
+|BASF| New Jersey | **Closed** |
+|[Moody's Analytics](https://careers.moodys.com/jobs/18781BR-2021-engineering-and-technology-summer-internship-new-york-omaha-san-francisco-waltham-west-chester/) | NY, SF, Omaha, Waltham, West Chester | Engineering and Tech Internship|
+|[Amazon](https://www.amazon.jobs/en/jobs/1204415/software-development-engineer-internship-summer-2021-us?ref=PittCSC) | Various | [Security Engineering](https://www.amazon.jobs/en/jobs/1229331/security-engineer-internship-summer-2021-us)|
+|[Citrix](https://jobs.citrix.com/job/R22175/Software-Engineer-Intern-2021?utm_campaign=pittcsc&utm_source=pittcsc&utm_medium=organic) | Florida | |
+|Central Intelligence Agency (CIA) | Washington, D.C. | **Closed** Must be US Citizen (Dual-Citizens are eligible) |
+| Bank of America| US & Canada | **Closed** |
+|[Honeywell](https://careers.honeywell.com/us/en/job/HONEUSREQ238487EXTERNALENUS/Computer-Software-Engineer-Computer-Science-Summer-2021-Intern-Co-Op?utm_source=PittCSC)| Various | |
+|[Palantir](https://jobs.lever.co/palantir/72018fcf-e777-4696-956c-a764966a4c75/apply) | Various | Forward Deployed [here](https://jobs.lever.co/palantir/a580fa16-06b0-4e4d-a597-60b7cd5b7ea1) |
+|Chick-fil-a | Atlanta | **Closed**|
+|[Robinhood](https://boards.greenhouse.io/robinhood/jobs/2214472?t=PittCSC) | Menlo Park, CA | More [positions](https://boards.greenhouse.io/robinhood?gh_src=PittCSC) here, two application max |
+|[Qualtrics](https://www.qualtrics.com/careers/us/en/job/QUALUS87166EXTERNALENUS/Software-Engineering-Intern-Summer-2021-Provo-UT?utm_source=PittCSC) | Seattle, Provo | [Seattle](https://www.qualtrics.com/careers/us/en/job/QUALUS151240EXTERNALENUS/Software-Engineering-Intern-Summer-2021-Seattle-WA?utm_source=PittCSC)  |
+|Scale AI| San Francisco, CA | **Closed** |
+|[JP Morgan](https://jpmc.fa.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001/job/210013662/?utm_medium=jobshare&utm_source=PittCSC) | Various | International students on F-1 Visa may not be considered |
+|[Duolingo](https://boards.greenhouse.io/duolingo/jobs/4867820002) | Pittsburgh, PA | **Duolingo Thrive is closed** |
+|Red Ventures| Charlotte, NC | **Closed** |
+|Texas Instruments | Dallas, TX | **Closed** |
+|[Los Alamos National Laboratory](https://jobszp1.lanl.gov/OA_HTML/OA.jsp?page=/oracle/apps/irc/candidateSelfService/webui/VisVacDispPG&OAHP=IRC_EXT_SITE_VISITOR_APPL&OASF=IRC_VIS_VAC_DISPLAY&akRegionApplicationId=821&transactionid=1759536200&retainAM=N&addBreadCrumb=RP&p_svid=81425&p_spid=3628350)| Los Alamos, NM| |
+|[Coursera](https://jobs.lever.co/coursera/361ef85d-9b6e-4225-9e05-809adb33eceb) | Remote - USA | |
+|[Cisco Meraki](https://jobs.cisco.com/jobs/SearchJobs/2021%20Meraki?listFilterMode=1&21178=%5B169482%5D&21178_format=6020) | Chicago, IL; San Francisco | |
+|UnifyID | Redwood City, CA | **Closed** |
+|Capital One| Various | **Closed** |
+|[Lockheed Martin](https://www.lockheedmartinjobs.com/search-jobs/2021/United%20States/694/1/2/6252001/39x76/-98x5/50/2) | Various | US Citizenship required |
+|General Mills| Minneapolis, MN | |
+|[Valkyrie Trading](https://jobs.lever.co/valkyrietrading/2da1578a-7a20-41db-83bd-cb16e4e8a112/apply) | Chicago, IL | |
+|[IBM](https://careers.ibm.com/ShowJob/Id/961831/Front-End-Developer-Summer-Intern-2021/?lang=en) | Various | [Backend position here](https://careers.ibm.com/ShowJob/Id/961980/Back-End-Developer-Summer-Intern-2021/?lang=en)|
+|[BNY Mellon](https://jobs.bnymellon.com/jobs/2007833) | New York, Pittsburgh, Jersey City | |
+|Motorola | Schaumburg, IL | **Closed** |
+|Cargill| Hopkins, MN | **Closed** |
+|[Dropbox](https://www.dropbox.com/jobs/listing/2265990?gh_jid=2265990) | San Francisco | |
+|Platform9| Mountain View | **Closed** |
+|HubSpot | Cambridge, MA | **Closed** |
+|Stripe | Seattle, NYC, San Francisco | **Closed** |
+|Zipline | San Francisco | **Closed** |
+|[Citi](https://citi.avature.net/careers/ProjectDetail/Dallas-Texas-United-States-NAM-Global-Consumer-Technology-Summer-Analyst-Dallas-North-America-2021-/10675) | North America | |
+|[Qualcomm](https://qualcomm.wd5.myworkdayjobs.com/en-US/External/job/San-Diego/IT-Internship---Summer-2021_3001435)| San Diego | Also available [Hardware Engineering](https://qualcomm.wd5.myworkdayjobs.com/en-US/External/job/San-Diego/Hardware-Engineering-Internship--Summer-2021-_3001376), [Systems Engineering](https://qualcomm.wd5.myworkdayjobs.com/en-US/External/job/San-Diego/Systems-Engineering-Internship--Summer-2021-_3001377), and [Embedded Software Engineering](https://qualcomm.wd5.myworkdayjobs.com/en-US/External/job/San-Diego/Embedded-Software-Engineering-Internship--Summer-2021-_3001371) |
+|[MLH](https://fellowship.mlh.io/) | Various Remote | [Explorer](https://fellowship.mlh.io/programs/explorer) and [Open Source](https://fellowship.mlh.io/programs/open-source) Fellowships, Fall, Spring, Summer available (UPDATE: Externships now available for Fall, Spring and Summer! Refer [MLH externships](https://fellowship.mlh.io/programs/externship) site for more info) & [MLH Coach](https://mlh.io/coaches) positons now available (optional if you want to help others)|
+|[MasterCard](https://mastercard.wd1.myworkdayjobs.com/en-US/Campus/job/Arlington-Virginia/Software-Development-Engineer-Intern--Summer-2021-_R-111190?source=PittCSC) | Arlington, VA | Open to all students |
+|Vail Systems| Chicago, Illinois | **Closed** |
+|Medtronic| Minneapolis, Minnesota | **Closed** |
+|[Clever](https://clever.com/about/careers/detail?gh_jid=6194&gh_src=PittCSC)| San Francisco, CA | |
+|[Salesforce](https://salesforce.wd1.myworkdayjobs.com/Futureforce_Internships/1/refreshFacet/318c8bb6f553100021d223d9780d30be) | Various | [Software Engineer](https://salesforce.wd1.myworkdayjobs.com/en-US/Futureforce_Internships/job/California---San-Francisco/Summer-2021-Intern---Software-Engineer--MuleSoft_JR72336-1), [Software Engineer(Security)](https://salesforce.wd1.myworkdayjobs.com/en-US/Futureforce_Internships/job/California---San-Francisco/Summer-2021-Intern-Software-Engineer--Security-_JR70210), [Software Engineer, Business Technology(IT)](https://salesforce.wd1.myworkdayjobs.com/en-US/Futureforce_Internships/job/Texas---Dallas/Summer-2021-Intern---Software-Engineer--Business-Technology--IT-_JR74858-2) and other intern positions are available. Winter internships are available too. |
+|Workiva| Scottsdale, AZ |**Closed** Must be authorized to work in the United States and not require sponsorship now or in the future |
+|[Figma](https://jobs.lever.co/figma/4fe2557e-3ac3-49ea-8330-9e6c49493f8e/apply) | San Francisco, CA | |
+|Patreon | San Francisco, CA | **Closed** |
+|[Kohl's](https://careers.kohls.com/internships/technology-jobs#software-engineer-intern) | Milwaukee, Milpitas | Various positions|
+|[Zillow](https://careers.zillowgroup.com/ShowJob/JobId/458252/SoftwareDevelopmentEngineerIntern)| Irvine, New York, Seattle | |
+|McKinsey| Boston, Chicago, New Jersey, NYC, SF| **Closed** |
+|[Microsoft](https://careers.microsoft.com/us/en/job/870957/Internship-Opportunities-for-Students-Software-Engineer) | Various | **Closed** |
+|[NetApp](https://jobs.netapp.com/job/Sunnyvale-Intern-Software-&-QA-Engineer-CA-94089/668051300/) | Various | [Advanced Technology Group](https://jobs.netapp.com/job/Research-Triangle-Park-Intern-Advanced-Technology-Group-1-NC-27709/667086400/) and [IT](https://jobs.netapp.com/job/Research-Triangle-Park-Intern-Information-Technology-NC-27709/667086100/) |
+|[Twitch](https://boards.greenhouse.io/twitch/jobs/4827849002?gh_src=PittCSC)| Seattle, Irvine, San Francisco | |
+|Snap| Los Angeles, Seattle, San Francisco, New York, Mountain View | **Closed**|
+|Benchling| San Fran, Boston | **Closed** |
+|[Target](https://jobs.target.com/job/-/-/1118/17057382)| Minneapolis | |
+|[Emerson]| Austin,TX| **Closed** |
+|[Applied Intuition](https://jobs.lever.co/applied/c22805d5-2006-4867-bb32-671951b17206/apply) | Mountain View | |
+|Tableau | Seattle, Palo Alto | **Closed** |
+|Qumulo| Seattle | **Closed** |
+|[Intuitive](https://careers.intuitive.com/jobs/201638?lang=en-us)| Sunnyvale | |
+|Fidelity Investments | Jersey City, NJ; Boston, MA; Merrimack, NH; Smithfield, RI; Durham, NC; and Westlake, TX | **Closed** |
+|[General Electric](https://jobs.gecareers.com/global/en/job/3495072/Digital-Technology-Intern-2021)| Various| |
+|[Raytheon](https://jobs.rtx.com/search-jobs) | Various | Click on Filter > Job Type > Intern, US Citizenship required|
+|[Johnson & Johnson](https://jobs.jnj.com/jobs/0438200814?lang=en-us) | Horsham, Pennsylvania; West Chester, Pennsylvania; Various | Permanent Work Authorization in the US required|
+|ARM| Austin, TX; San Jose, CA; Boston, MA | Closed |
+|[Amazon Web Services](https://www.amazon.jobs/en/search?offset=0&result_limit=10&sort=relevant&category=software-development&business_category[]=amazon-web-services&distanceType=Mi&radius=24km&latitude=&longitude=&loc_group_id=&loc_query=&base_query=2021&city=&country=&region=&county=&query_options=&) | Virginia | Requires US Citizenship and Clearance. |
+|[SurveyMonkey](https://www.surveymonkey.com/careers/2466488-data-science-intern-summer-2021/)| San Mateo, CA | |
+|[Tesla](https://www.tesla.com/careers/job/software-fullstackengineeringinternshipspringand-orsummer2021-68849)|Fremont, Palo Alto, Bellevue, others| More [here](https://www.tesla.com/careers/search#/?keyword=intern&department=3&region=5) |
+|[Church of Latter Day Saints](https://careersearch.churchofjesuschrist.org/public/jobdetail.aspx?jobid=261905) | Utah | Must be a Mormon |
+|[SIG](https://careers.sig.com/job/SUSQA004Y4604/Trading-Intern) | Bala Cynwyd, PA | Trading, SWE [here](https://careers.sig.com/job/SUSQA004Y4957/Software-Engineering-Internship-Program) |
+|Stonebranch | Alpharetta, GA | |
+|[Mathworks](https://www.mathworks.com/company/jobs/opportunities/10071-edg-intern-bachelor-computer-science-majors?keywords=intern&location%5B%5D=US) | Natick, MA | |
+|Samsara | San Francisco, Atlanta | **Closed** |
+|Walmart| Bentonville, AR | **Closed** |
+|[Wolverine Trading](https://chu.tbe.taleo.net/chu01/ats/careers/v2/viewRequisition?org=WOLVE&cws=37&rid=310) | Chicago, IL | |
+|[Coupang](https://boards.greenhouse.io/coupang/jobs/2080981) | Mountain View, California | |
+|Coinbase | Remote  | **Closed** |
+|Toyota | Plano, TX | **Closed**|
+|[Verkada](https://jobs.lever.co/verkada/fcfb0cde-9e89-4be9-8df5-e35e11430297/apply) | San Mateo, CA | Front End, [Back End](https://jobs.lever.co/verkada/fcfb0cde-9e89-4be9-8df5-e35e11430297), [Comp Vision](https://jobs.lever.co/verkada/be4d736c-9319-4223-b9f2-9f892bf67d85), [Embedded Systems](https://jobs.lever.co/verkada/170f77fc-25c2-4594-8844-6e89c1f0ef91), [Mobile Engineering](https://jobs.lever.co/verkada/c58803d1-33ef-44af-a519-921b19e7691f)|
+|[Nvidia](https://nvidia.wd5.myworkdayjobs.com/en-US/UniversityJobs/job/US-CA-Santa-Clara/Software-Intern--GPU-Communication-Libraries_JR1934897)| Austin, Westford, Redmond, Champaign, Santa Clara | More [here](https://nvidia.wd5.myworkdayjobs.com/UniversityJobs/10/refreshFacet/318c8bb6f553100021d223d9780d30be)|
+|[Plaid](https://plaid.com/job/?id=4e0c92e3-4c27-44a1-8d9d-be4fa18f987c) | San Fran |  Apply by API |
+|[Bloomberg](https://careers.bloomberg.com/job/detail/84150) | New York |   |
+|[FactSet](https://factset.wd1.myworkdayjobs.com/en-US/FactSetCareers/job/New-York-NY-USA/Software-Engineering-Internship---US-Campus_R7759) | NY, Chicago, Boston, Norwalk, Austin | |
+|[Asana](https://asana.com/jobs/apply/2256911/intern--software-engineering-) | SF, NYC | |
+|MasterCard | NYC, Arlington | **Closed** Open to students enrolled in a bachelor’s degree program | 
+|[XPO Logistics](https://jobs.xpo.com/US/job/Portland-Software-Development-Intern-OR-97209/669686500/?utm_source=PittCSC) | Portland, OR | |
+|[eBay](https://jobs.ebayinc.com/job/-/-/403/1006890272?source=PittCSC)| San Jose, Austin, Bellevue, New York, Portland | |
+|Dell| Round Rock, Austin, TX | **Closed** In some positions, applicants must be legally authorized to work in the United States. |
+|[Epic Games](https://epicgames.wd5.myworkdayjobs.com/en-US/Epic_Games/job/Cary-NC/Epic-Games-Programming-Internships_R2792-2)| Cary, NC | |
+|[Ocient](http://www.ocient.com/careers?gh_jid=4105471003&gh_src=PittCSC) | Chicago, IL | Ocient is building the world's largest database. Ocient is looking for Software Engineers and Software Engineering Interns. |
+|[Anduril](https://jobs.lever.co/anduril/d15840b6-081b-4d4c-95ed-008d681b4f7f/apply)| Seattle, Irvine |  Perception Intern [here](https://jobs.lever.co/anduril/9312d9f4-ce3b-43b8-b870-d86bfc838135); U.S. Person status may be required|
+|[Marvell](https://marvell.wd1.myworkdayjobs.com/en-US/MarvellCareers/job/Santa-Clara-CA/Software-Engineer---Flash-Firmware-Intern_2001010?source=PittCSC)| Santa Clara, CA | |
+|[Sony](https://boards.greenhouse.io/sonyinteractiveentertainmentplaystation/jobs/2309169)| Santa Monica, San Jose |[Research Intern](https://sonyglobal.wd1.myworkdayjobs.com/en-US/SonyGlobalCareers/job/San-Jose/Intern---Advanced-Computer-Vision---Graphics-Research_JR-102445)| |
+|[Cubist](https://careers.point72.com/CSJobDetail?jobName=2021-cubist-software-engineering-internship-program&jobCode=CSS-0004136)| NY | |
+|[MongoDB](https://www.mongodb.com/careers/jobs/2309781) | NY, SF, Austin | |
+|[HP](https://careers.hpe.com/job/Hewlett-Packard-Enterprise-San-Jose-California/118653859) | San Jose | |
+|[Wayfair](https://www.wayfair.com/careers/job/priority-period---software-engineer-intern---summer-2021-/4848614002/apply?utm_source=PittCSC) | Boston |  |
+|[Appian](https://www.appian.com/careers/search/job/?gh_jid=2266649&job_name=software-engineer-intern&location=mclean-virginia) | Mclean, VA | |
+|[Yext](https://boards.greenhouse.io/yext/jobs/2301556) | NYC, DC | |
+|[WillowTree](https://willowtreeapps.com/careers/jobs/4698742002/software-engineer-intern) | Charlottesville, Columbus, Durham | |
+|[Textron](https://textron.taleo.net/careersection/textron/jobdetail.ftl?job=284652)| Maryland | Cyber Engineering, [Software Engineering](https://textron.taleo.net/careersection/textron/jobdetail.ftl?job=1019418) |
+|Playstation | Various in CA | **Closed** More positions here |
+|[ServiceNow](https://jobs.jobvite.com/careers/servicenow/job/oFfedfw5?__jvsd=PittCSC) | Various | |
+|[Stryker](https://stryker.wd1.myworkdayjobs.com/en-US/StrykerCareers/job/Kalamazoo-Michigan/Summer-Internship-2021-Computer-Science--Computer-Engineering--Software-Michigan_R436511-1)| Michigan |Must be permanent resident of the U.S. or U.S. citizen |
+|[CrowdStrike](https://crowdstrike.wd5.myworkdayjobs.com/en-US/crowdstrikecareers/job/USA---Irvine-CA/Software-Engineer-Internship--Summer-2021-_R1556)| Irvine, Kirkland, Sunnyvale, Minneapolis| |
+|[Osisoft](https://osisoft.wd1.myworkdayjobs.com/en-US/osisoft_careers/job/San-Leandro-California-USA/Software-Developer-Intern---Summer-2021_R002670) | San Leandro, Scottsdale, Philadelphia, Johnson City| |
+|[Datadog](https://www.datadoghq.com/careers/detail/?gh_jid=2265934)| Boston, NYC | |
+|Tanium| Remote, Morrisville, NC | **Closed**|
+|[Lyft](https://boards.greenhouse.io/lyft/jobs/4832208002?gh_jid=4832208002)| San Francisco, CA | |
+|[Nutanix](https://nutanix.eightfold.ai/careers?pid=1637065&domain=nutanix.com)| San Jose, CA | |
+|[Etsy](https://www.etsy.com/careers/job/743999718641018) | Brooklyn, NY | |
+|[Virtu Financial](https://boards.greenhouse.io/virtu/jobs/4792595002) | NYC | |
+|Ginkgo Bioworks | Boston, MA | **Closed** |
+|Home Depot| Atlanta, GA | **Closed** |
+|[Lowes](https://sjobs.brassring.com/TGnewUI/Search/home/HomeWithPreLoad?PageType=JobDetails&partnerid=25239&siteid=5014&jobid=6674182#jobDetails=6674182_5014) | Mooresville| |
+|Path AI | Boston, MA | **Closed** |
+|Splunk | San Fran | **Closed** Software Engineering here |
+|[Washington Post](https://docs.google.com/forms/d/e/1FAIpQLScwbYDTH-tE5yobarHzuYBqCGRVg6CTn01KCFaM9mG-4Ty_kA/viewform) | DC | Publishing Tools Internship [here](https://docs.google.com/forms/d/e/1FAIpQLSck3QDvOkBap9sbpVWaDDTw2UfzCPHq_Cx7bfySRtoMeH6-jg/viewform)|
+|[Gatik](https://jobs.lever.co/gatik/363a3a47-a59c-49a3-9007-b1389db38969/apply)|Palo Alto, CA | |
+|Cockroach Labs| NYC | **Closed** |
+|[Roblox](https://corp.roblox.com/careers/listing/?gh_jid=2311474)|San Mateo, CA | |
+|Domo| American Fork, UT | |
+|[Statefarm](https://findjobs.statefarm.com/ShowJob/Id/460685/Intern%20%20%20Technology) | Various | |
+|[Samsung](https://sec.wd3.myworkdayjobs.com/Samsung_Careers) | Austin, San Jose | Software Engineering Position **Closed** but other positions are still available |
+|[Expedia](https://lifeatexpediagroup.com/jobs/job?jobid=R-55588) | Seattle, WA | |
+|[Fivestars](https://www.fivestars.com/careers/?gh_jid=2324334) | SF | |
+|PeachPay | Ames, Iowa | Closed |
+|Plexus | Raleigh, NC | **Closed** |
+|[Goodyear](https://jobs.goodyear.com/job/San-Francisco-Global-Technology-Software-Engineering-Intern%2C-New-Ventures-Group-San-Francisco%2C-CA-CA-94101/673042000/?feedId=235900&utm_source=PittCSC) | SF | |
+|[KnowBe4](https://www.knowbe4.com/jobs?gh_jid=4858556002) | Clearwater, Florida | | 
+|Gap | SF | **Closed** |
+|[American Express](https://jobs.americanexpress.com/jobs/20006515?lang=en-us&previousLocale=en-US) | Various | |
+|[Silicon Labs](https://jobs.jobvite.com/silabs/job/oyymdfwp) | Austin, TX | |
+|Blackstone | NYC | |
+|[PEAK6](https://boards.greenhouse.io/capitalmanagement/jobs/2260071) | Chicago, IL | for those who identify as female, also have PM and trading intern positions|
+|[Oracle](https://oracle.taleo.net/careersection/3/jobdetail.ftl?job=20000POC) | Various | |
+|[Verizon](https://www.verizon.com/about/work/jobs/5558860-software-development-summer-2021-internship) | San Jose, CA| Requires authorization to work in the U.S. without restrictions or need for future sponsorship|
+|[Nike](https://jobs.nike.com/job/URSRCTECHUI21?from=PittCSC) | Beaverton, Oregon | |
+|[Uber](https://www.uber.com/global/en/careers/list/62848/) | SF | |
+|iCims | Holmdel, NJ | **Closed** |
+|[Databricks](https://databricks.com/company/careers/open-positions/job?gh_jid=4780022002) | SF | |
+|[Twilio](https://boards.greenhouse.io/twilio)| San Francisco, CA; Denver, CO | |
+|[C3.ai](https://boards.greenhouse.io/c3iot/jobs/4086849002?gh_src=PittCSC) | Redwood City, CA | |
+|[Mitchell](https://careers-mitchell.icims.com/jobs/search?ss=1&searchKeyword=software+intern) | Coppell, Irvine, San Diego | |
+|[CME Group](https://jobs.cmegroup.com/jobs/5571787-software-engineering-internship-summer-2021?bid=305#start) | Chicago, IL | |
+|[Squarespace](https://www.squarespace.com/careers/jobs/2329528) | NYC | |
+|[Teradata](https://careers.teradata.com/jobs/208210/software-engineering-intern)| San Diego, CA | |
+|[Thrivent](https://thrivent.wd5.myworkdayjobs.com/en-US/external/job/WI---Appleton/Software-Developer-Internship--Summer-2021_REQ-21517)| Appleton, WI; Minneapolis, MN
+|[Garmin](https://careers-us.garmin.com/us/en/job/200017Q/Software-Engineer-Intern-Brea-CA-Summer-2021) | Brea, CA | |
+|[MemSQL](https://boards.greenhouse.io/singlestore/jobs/2328598)| SF, Seattle | |
+|[ASML](https://www.asml.com/en/careers/find-your-job/1/8/6/software-engineering-intern-san-joseasml-req18667?utm_source=PittCSC)| San Jose | |
+|Sezzle| Minneapolis, MN | **Closed** |
+|[Activision](https://careers.activision.com/job/ACPUUSR003077EXTERNAL/Web-Development-Intern?utm_source=pittcsc)| Santa Monica, CA;Vancouver, BC | [Canada Position](https://careers.activision.com/job/ACPUUSR003096EXTERNAL/Software-Development-Internship?utm_source=pittcsc) |
+|[Veeva](https://jobs.lever.co/veeva/066ef3bb-a24d-4c56-8f2b-2f3d1fcfafc8) | Pleasanton, CA | |
+|[SpaceX](https://boards.greenhouse.io/spacex/jobs/4867821002?gh_jid=4867821002) | Various |Must be a U.S. citizen, lawful permanent resident of the U.S., protected individual, or eligible to obtain the required authorizations from the U.S. Department of State|
+|[InfoTech](https://recruiting.ultipro.com/INF1010INFT/JobBoard/a1f626ce-9a88-4c30-86ee-6562ee8ea030//OpportunityDetail?opportunityId=e61387c1-8afd-4373-9852-1e35d441ba85) | Gainesville, FL | |
+|[Tanium](https://www.tanium.com/careers/2291599?gh_jid=2291599) | Remote | |
+|[TuSimple](https://boards.greenhouse.io/tusimplerelocationjobs/jobs/4872685002) | Boston | MS/PhD|
+|[Cognite](https://apply.workable.com/cognite/j/577B0208A9/) | Houston | |
+|[Slack](https://slack.com/careers/2322106/software-engineering-internship) | Remote | |
+|[DoorDash](https://boards.greenhouse.io/doordash/jobs/2333469/) | SF | |
+|Waymo | Mtn View | **Closed** Trucking pos here | 
+|Pure Storage | Mountain View | **Closed** Software Engineering |
+|New Relic | Portland | **Closed** |
+|[Kensho](https://jobs.lever.co/kensho/6d510556-b646-4af6-aad5-227625d9727d/apply) | Cambridge | [Front End](https://jobs.lever.co/kensho/312ae842-2798-4021-b76f-33e11c504d71), [Query Infrastructure](https://jobs.lever.co/kensho/f1d84d9a-c754-4f7f-97d4-b87443fb2e60) |
+|Lucid | Salt Lake City ,UT | **Closed** |
+|[Addepar](https://boards.greenhouse.io/addepar1?t=31a4a9852)| Remote, USA | [SRE Tools](https://boards.greenhouse.io/addepar1/jobs/5140174002?t=31a4a9852), [Software Engineer (Data Engineering)](https://boards.greenhouse.io/addepar1/jobs/5140213002?t=31a4a9852), [Software Engineer - Webcore](https://boards.greenhouse.io/addepar1/jobs/5140304002?t=31a4a9852) and other Intern positions are available. |
+| Deliverr | SF | |
+|[Viasat](https://careers.viasat.com/careers/FolderDetail/Software-Engineer-Intern/5765) | Carlsbad, CA | Must be a U.S. citizen, lawful permanent resident of the U.S., protected individual, or eligible to obtain the required authorizations from the U.S. Department of State |
+|[Barclays](https://joinus.barclays/americas/internships/developer-summer-analyst) | Whippany, NJ | More positions [here](https://barclays.taleo.net/careersection/12/jobsearch.ftl?lang=en_GB)|
+|[Anyscale](https://jobs.lever.co/anyscale/31505685-4719-44c5-b7d1-e8409b233da5/apply) | SF | |
+|[Paylocity](https://www.paylocity.com/careers/career-opportunities/early-career/?jobId=4130) | Schaumberg, IL | Data Science [here](https://www.paylocity.com/careers/career-opportunities/early-career/?jobId=4175) | |
+|Pinterest | San Francisco, Palo Alto, Seattle, Toronto | **Closed** | 
+|[Esri](https://www.esri.com/careers/software-development-and-engineering-2021-internships-13003) | Redlands Vienna, VA Denver Arlington Portland (Maine and Oregon) | |
+|NextDoor | SF | |
+|[Gusto](https://boards.greenhouse.io/gusto/jobs/2315797) | SF, Denver, NYC | |
+|[Dick's](https://www.dickssportinggoods.jobs/job-search-results/?category[]=Students%20%26%20Recent%20Grads) | Pittsburgh, Nationwide | Data Science, Software Engineering, UX Design. Prefer juniors. |
+|SK Hynix| San Jose | **Closed** |
+|AutoDesk| California, Michigan, Massachusetts, Oregon | **Closed** |
+|[Strava](https://boards.greenhouse.io/strava/jobs/2336808) | San Francisco | iOS, [Android](https://boards.greenhouse.io/strava/jobs/2336822), [Platform](https://boards.greenhouse.io/strava/jobs/2336973), [Server](https://boards.greenhouse.io/strava/jobs/2336895) positions | |
+|[Riot Games](https://www.riotgames.com/en/work-with-us/job/2337878/software-engineer-intern-los-angeles-usa)| Los Angeles | More positions [here](https://www.riotgames.com/en/university-programs) |
+|[GoDaddy](https://boards.greenhouse.io/eventsandinterns)| Kirkland, WA | [SDE](https://boards.greenhouse.io/eventsandinterns/jobs/4180310003), [PM](https://boards.greenhouse.io/eventsandinterns/jobs/4176462003), [UX](https://boards.greenhouse.io/eventsandinterns/jobs/4168260003), [Business Analytics](https://boards.greenhouse.io/eventsandinterns/jobs/4276354003) and other positions |
+|[TerraSim, Inc.](https://apply.workable.com/bohemia-interactive-simulations-inc/j/3822C827D7/) | Pittsburgh | US Citizenship required|
+|[Indeed](https://indeed.avature.net/SWEintern) | Various | |
+|[Epic Systems](https://epic.avature.net/Careers/FolderDetail/Software-Developer-Intern---Summer-2021/19231) |  Minneapolis, Madison, Rochester,MN | Must be eligible to work in the United States without visa sponsorship |
+|Credera | Various | |
+|Toast| Boston, MA | Closed |
+|Spotify | New York, Boston | **Closed** |
+|[Smith Micro](https://jobs.lever.co/smithmicro/47b315f1-e798-4139-abd1-35da544a02b3/apply)|Pittsburgh, PA|Mobile Applications, Enterprise and Consumer software|
+|[Cadence](https://www.cadence.com/en_US/home/company/careers/interns-and-new-grads.html)| San Jose CA, Pittsburgh PA, Boston MA| Software and Electrical Engineering services| 
+|Ford| Dearborn, MI| **Closed** | 
+|ThoughtSpot | Sunnyvale, CA | **Closed** |
+|[Blizzard](https://careers.blizzard.com/global/en/job/R003243/Software-Engineering-Internship) | Irvine, CA | [SRE](https://careers.blizzard.com/global/en/job/R003244/Site-Reliability-Engineering-Internship), [Data Science](https://careers.blizzard.com/global/en/job/R003193/Data-Science-Internship), [Security](https://careers.blizzard.com/global/en/job/R003289/Security-Engineering-Internship), [Game Dev](https://careers.blizzard.com/global/en/job/R003252/Game-Development-Engineering-Internship) |
+|[Spectrum](https://jobs.spectrum.com/job/greenwood-village/2021-summer-intern-engineering/4673/17260817) | Greenwood Village, CO | |
+|Code42 | Minneapolis, MN | **Closed** |
+|[KeepTruckin](https://boards.greenhouse.io/keeptruckin/jobs/4877625002) | SF, CA | |
+|[Zynga](https://jobs.jobvite.com/zynga/job/o73vdfwC) | SF, CA | |
+|[Google](https://careers.google.com/jobs/results/93981708417671878-software-engineering-intern-bachelors-summer-2021/)| Various | [STEP (First Year)](https://careers.google.com/jobs/results/134007951758107334-step-intern-first-year-student-summer-2021/) [STEP (Second Year)](https://careers.google.com/jobs/results/93605726980580038-step-intern-second-year-student-summer-2021/)|
+|[Better.com](https://boards.greenhouse.io/better/jobs/2346546) | NYC | |
+|Chan Zuckerberg Initiative| Redwood City, CA | **Closed** |
+|Sleep Number | San Jose, CA | **Closed** |
+|[Blend](https://jobs.lever.co/blendlabs/2a469512-a8c2-44fa-a260-ef3ae0c90db7/apply) | SF, CA | |
+|[Wealthfront](https://jobs.lever.co/wealthfront/0603035b-4d32-4306-8592-bd8df7ddbafc/apply) | Palo Alto, CA | |
+|[Marvell](https://marvell.wd1.myworkdayjobs.com/en-US/MarvellCareers/job/Santa-Clara-CA/Software-Engineer-Intern_2001165) | Santa Clara | |
+|Zoox| Foster City, CA | **Closed** |
+|[DrChrono](https://jobs.lever.co/drchrono/21582edc-3f0d-47fd-981b-9dbe7a07939a/) | Sunnyvale, CA | |
+|[Intel](https://jobs.intel.com/page/show/search-results#q=2021&t=Jobs&sort=relevancy&layout=table&f:@countryfullname=[United%20States]&f:@employeetype=[Intern%2FStudent]) | Phoenix, AZ | Must be U.S. Citizen, U.S. National, U.S. Lawful Permanent Resident, or a person granted Refugee or Asylum status by the U.S. Government.|
+|[Cloudflare](https://boards.greenhouse.io/cloudflare/jobs/2348769?gh_jid=2348769) | Austin, Champaign, Kirkland, San Fran | |
+|[Kleiner Perkins](https://boards.greenhouse.io/2021kpfellows/jobs/4877715002) | Bay Area | |
+|[Sentry](https://boards.greenhouse.io/sentry/jobs/2347712) | SF | |
+|[Under Armour](https://www.wayup.com/i-Internet-j-Software-Hardware-Engineering-Rookie-2021-Summer-Intern-Under-Armour-208948438685274/) | San Francisco, Baltimore, Austin | |
+|[Pocket Gems](https://boards.greenhouse.io/pocketgems/jobs/2334655) | SF | |
+|[Kiva](https://boards.greenhouse.io/kivaorg/jobs/2349814?gh_jid=2349814)| Remote | |
+|[Chewy](https://www.chewy.com/jobs/position/2353210?gh_jid=2353210&gh_jid=2353210)| Boston, MA | |
+|Convoy| Seattle, WA | **Closed** |
+|[Blue Origin](https://blueorigin.wd5.myworkdayjobs.com/en-US/BlueOrigin/job/Kent-WA/Summer-2021-Internship--Avionics-Software_R5000?mode=job) | Kent, WA ; Merritt Island, FL | Must be a U.S. citizen or national, U.S. permanent resident (current Green Card holder), or lawfully admitted into the U.S. as a refugee or granted asylum.|
+|[Teamworthy Ventures](https://boards.greenhouse.io/teamworthy/jobs/4163159003) | NYC | |
+|[Thomson Reuters](https://jobs.thomsonreuters.com/ListJobs/All/Search/jobtitle/2021/)| Eagan-Minnesota-United States of America | No visa-sponsorships available. DevOps, Software Engineering, Database and other positions are available. |
+|Redfin| Seattle, Frisco, San Francisco | Closed |
+|[Poshmark](https://boards.greenhouse.io/poshmark/jobs/2354571) | Redwood City | Android, [iOS](https://boards.greenhouse.io/poshmark/jobs/2350507), [Big Data](https://boards.greenhouse.io/poshmark/jobs/2351485), [Infrastructure](https://boards.greenhouse.io/poshmark/jobs/2350447), [Full Stack](https://boards.greenhouse.io/poshmark/jobs/2349686), [DevOps](https://boards.greenhouse.io/poshmark/jobs/2350481), [Web App](https://boards.greenhouse.io/poshmark/jobs/2351446) |
+|[Vatic Labs](http://www.vaticlabs.ai/careers/2341264/?gh_jid=2341264) | NYC | |
+|[Cerner](https://careers.cerner.com/job/67087BR) | Kansas City, MO | |
+|[Real-Time Innovations](https://boards.greenhouse.io/rti/jobs/2337803)| Sunnyvale, CA;Denver,CO | |
+|[Adobe](https://adobe.wd5.myworkdayjobs.com/en-US/external_university/job/Boston/Software-Development-Intern--Adobe-Sign-Enterprise_R100956-1)|San Jose | |
+|[Snowflake](https://careers.snowflake.com/us/en/job/4867943002/Software-Engineer-Intern-Front-End-Summer-2021) | San Mateo, CA | [Core Engineering](https://careers.snowflake.com/us/en/job/4889064002/Software-Engineer-Intern-Core-Engineering-Summer-2021), [Infrastructure Automation](https://careers.snowflake.com/us/en/job/4867934002/Software-Engineer-Intern-Infrastructure-Automation-Summer-2021) |
+|Helbiz| New York City, NY | **Closed** |
+|Oshkosh Corporation| Greencastle, PA ; Hagerstown, MD | **Closed** Software Engineering, IT Internship|
+|Duck Creek Technologies| Basking Ridge, NJ | **Closed** |
+|[Chemours](https://chemours.wd5.myworkdayjobs.com/Chemours/job/US---DE---Wilmington-Headquarters/Software-Developer-Summer-Intern_JR5427)| Wilmington, DE |Candidates who now or in the future require sponsorship for employment (i.e., H1-B visa, F-1 visa (OPT), TN visa or any other non-immigrant status) are ineligible |
+|[Audible](https://www.amazon.jobs/en/jobs/1274977/audible-software-development-engineer-internship) | Trenton, NJ | |
+|[EA](https://ea.gr8people.com/jobs/162586/summer-2021-software-engineering-internship-bs-ms) | Various | |
+|Okta| SF, San Jose,  Bellevue, Toronto | **Closed** |
+|[Domeyard LP](https://boards.greenhouse.io/domeyard/jobs/1079185) | Boston | |
+|[McDonald's](https://jobs.smartrecruiters.com/oneclick-ui/company/McDonaldsCorporation/publication/3af1fbaf-b763-4898-b8c0-b62084481d3d?dcr_id=DCRA1) | Chicago | |
+|OfferUp| Various | **Closed** |
+|Spreetail | Lincoln, NE |  **Closed** |
+|[Ultimate Software](https://recruiting.ultipro.com/usg1006/JobBoard/dfc53730-57d1-3460-336f-ddafabd108f3//OpportunityDetail?opportunityId=7f5ef8ac-0077-433b-b96b-5a63c8c7693e)| Ft. Lauderdale, FL Atlanta, GA | |
+|[Cree](https://cree.wd5.myworkdayjobs.com/en-US/EXT/job/Durham-NC/Software-Development-Engineer-Intern_20-713) | Durham, NC | |
+|[Reddit](https://boards.greenhouse.io/reddit/jobs/2324527) | SF | |
+|HashiCorp | Remote | **Closed** |
+|[Affirm](https://boards.greenhouse.io/affirm/jobs/4124922003) | SF | |
+|Hulu| Santa Monica | **Closed** |
+|[Twitter](https://urapplication2021.splashthat.com/) | Remote | |
+|Oscar Health | NYC |**Closed** |
+|[Red Hat](https://us-redhat.icims.com/jobs/81433/software-engineering%2c-intern/job?hub=7&mobile=false&width=1140&height=500&bga=true&needsRedirect=false&jan1offset=-300&jun1offset=-240) | Remote | |
+|[Zebra Technologies](https://early-careers-zebra.icims.com/jobs/90588/2021-summer-internship---computer-vision/job?mobile=false&width=1241&height=500&bga=true&needsRedirect=false&jan1offset=-300&jun1offset=-240) | NY | |
+|[Collins Aerospace](https://jobs.collinsaerospace.com/search-jobs/2021?orgIds=1738&kt=1)| Various | Software Engineering, Data Analytics and other positions are available. Must be authorized to work in the U.S. without sponsorship now or in the future. |
+|Fanatics| Various | **Closed** |
+|[T-Mobile](https://www.tmobile.careers/job-details/engineering/150678BR-2021-software-engineerdeveloper-internship--product-and-technology)| Various | Software Engineering, [Data Analyst](https://www.tmobile.careers/job-details/engineering/150664BR-2021-data-analyst-internship--product-and-technology) and [IT](https://www.tmobile.careers/job-search?f=Information%20Technology&a=2021&dd=f). Must be authorized to work in the U.S. on a permanent basis without requiring sponsorship. |
+|[BlackBerry](https://bb.wd3.myworkdayjobs.com/Student/jobs)| Various | Software Development, Data Science, Test, Security positions are available. Also includes winter internships. |
+|Transamerica| Various | **Closed** Data science, Information Security, and other positions are available. |
+|[Thomson Reuters](https://jobs.thomsonreuters.com/ListJobs/ByKeyword/intern) | Various | |
+|[ADP](https://jobs.adp.com/job-search-results/?keyword=2021&language=en)| Various | [Application Development](https://jobs.adp.com/job/11379792/summer-2021-technology-internship-application-development-may-2022-grads-alpharetta-ga/) and more [here](https://jobs.adp.com/job-search-results/?keyword=2021&language=en). |
+|[Schonfeld](https://boards.greenhouse.io/schonfeld)| NYC | [DevOps](https://boards.greenhouse.io/schonfeld/jobs/2344543), [Software Engineering](https://boards.greenhouse.io/schonfeld/jobs/2344512), [Cybersecurity](https://boards.greenhouse.io/schonfeld/jobs/2344530), [Support Engineering](https://boards.greenhouse.io/schonfeld/jobs/2344552) |
+|[Sierra Nevada Corporation](https://www.sncorp.com/careers/open-positions/?Search=2021)| Various | Applicant must be a U.S. citizen. |
+|[Docusign](https://www.docusign.com/company/careers/open?gh_jid=2535507)| Seattle, WA; Remote | This role is not eligible for sponsorship or CPT. |
+|[Avanade](https://careers.avanade.com/jobsenus/SearchJobs/intern?3_56_3=19946&3_67_3=194784)| Boston, NYC, Philadelphia| |
+|[Merck](https://jobs.merck.com/us/en/job/R76119/2021-Database-Programming-Intern)| Various | Database Programming, [Data Science](https://jobs.merck.com/us/en/job/R72491/2021-Data-Science-Intern) and [other positions](https://jobs.merck.com/us/en/search-results?keywords=2021) are available. No visa sponsorship. |
+|Tokyo Electron| Various | **Closed** |
+|[Crestron Electronics](https://www.crestron.com/About/careers-jobs-employment-opportunities/Job-Search)| NYC, New Jersey, Texas | Firmware Engineering, Software Tools, Test Engineering and other positions are available.  |
+|[Bayer](https://career.bayer.com/en/job-searchs?search_api_fulltext=2021&field_job_career_level=All&field_job_functional_area=All&field_job_country=All&field_job_location=All&field_job_division=All)| New Jersey, Missouri | [Data Engineering](https://career.bayer.us/en/job/data-engineer-intern--SF263281) positions are available. |
+|[FireEye](https://www.fireeye.com/company/jobs.html)| Various | Cyber Security, Data Science, Information Technology and Software Engineering positions are available. |
+|[Novetta](https://www.novetta.com/careers/search-jobs/#2021)| McLean, Virginia | Information Technology, Machine Learning positions are available. Active Secret security clearance is needed. |
+|[Saturn Systems](https://saturnsystems.catsone.com/careers/1421-General/jobs/12769333-Programmer-Internships-for-2021)| Duluth, MN | Programmer Internships are available. |
+|[Volvo Group](https://xjobs.brassring.com/TGnewUI/Search/Home/Home?partnerid=25079&siteid=5171#keyWordSearch=2021)| Various | Programming Support, Digital & IT positions are available. |
+|[AMD](https://jobs.amd.com/go/Internships-&-Co-op-Opportunities/2567200/?q=&q2=&alertId=&locationsearch=&title=2021&location=)| Various | Autonomous Vehichle, Test Engineer and other positions are available. |
+|Relativity| Chicago | **Closed** |
+|[Group One Trading](https://group1.applicantpro.com/jobs/1537030.html) | Chicago | |
+|[Aegon](https://careers.aegon.com/en/vacancies/united-states/denver/other/data-science-internship-summer-2021/)| Denver | [Information Security](https://careers.aegon.com/en/vacancies/united-states/denver/other/information-security-internship-summer-2021/), [Technology Rotational](https://careers.aegon.com/en/vacancies/united-states/denver/administration/technology-rotational-internship-summer-2021/), Data Science positions are available. |
+|[Text-Em-All](https://callemall.applytojob.com/apply/YIO6hArmDY/Software-Engineering-Internship-SpringSummer-2021)| Frisco, TX | Software Engineering positions are available. The positions are temporarily remote. |
+|[Xactware](https://jobs.smartrecruiters.com/Verisk/743999720996128-software-engineering-intern-2021-summer-internship-program-cr)| [Jersey City, NJ.](https://jobs.smartrecruiters.com/Verisk/743999719362343-technical-opportunities-2021-summer-internship-program-cr); White Plains, NY; Houston, TX; Boston, MA; Lehi, UT, and San Francisco, CA | Software Engineering, [Info Sec](https://jobs.smartrecruiters.com/Verisk/743999719362248-it-infosec-intern-compliance-2021-summer-internship-program-cr), [Data Management](https://jobs.smartrecruiters.com/Verisk/743999719362534-developer-intern-enterprise-data-management-team-edm-2021-summer-internship-program-cr), [Cloud](https://jobs.smartrecruiters.com/Verisk/743999719362627-global-ops-aws-intern-2021-summer-internship-program-cr) positions are available. All candidates must have eligibility to work permanently in the U.S. |
+|[Hallmark Cards](https://careers.hallmark.com/job/Kansas-City-Engineering-Internship-Summer-2021-MO-64108/673164100/)| Kansas City, MO | [Analytics](https://careers.hallmark.com/job/Kansas-City-Analytics-Internship-Summer-2021-MO-64108/673166500/), [Information Technology](https://careers.hallmark.com/job/Kansas-City-Information-Technology-Internship-Summer-2020-1-MO-64108/673168200/) positions are available. Will only hire individuals lawfully authorized to work in the United States. |
+|Steelcase| East Windsor, CT, Grand Rapids, MI | **Closed** Software Development, Data Science positions are available. Must be authorized to work in the US without future need of sponsorship. |
+|[CACI International](https://careers.caci.com/ListJobs?keyword=2021&&Page=1&SortOrder=desc&SortField=AddedOn)| Various | Software Engineering, Information Technology, Cyber Security and other positions are available. The ability to obtain/maintain a clearance (U.S. Citizenship required). |
+|C.H Robinson| Eden Prairie, Minnesota | **Closed** Engineering Product Manager Intern position is available. |
+|[Anthem](https://anthemcareers.ttcportals.com/search/information-technology/jobs?q=2021)| Various | Developer, Data Analyst positions are available. |
+|NRC Health| Lincoln, NE | **Closed** This role will be remote with a potential for in-person activities. |
+|[UBS](https://jobs.ubs.com/TGnewUI/Search/home/HomeWithPreLoad?partnerid=25008&siteid=5131&PageType=searchResults&SearchType=linkquery&LinkID=6166#keyWordSearch=&locationSearch=&Function%20Category=Information%20Technology%20(IT))| Various | Analyst positions are available. |
+|[The Lubrizol Corporation](https://jobs.lubrizol.com/search/?q=2021&utm_source=CSSearchWidget&startrow=1) | Various | Data Scientist, Developer, Information Security and other positions are available. Fall internships are also available. Must be authorized to work in the United States without requiring work authorization sponsorship by our company for this position now or in the future. |
+|[Liberty Mutual Insurance](https://jobs.libertymutualgroup.com/search-jobs/?keyword=2021)| Various | TechStart Summer Internship Program is available. Cyber Security, Data Analyst and other positions are available. |
+|[Syneos Health Clinical Solutions](https://incresearch.taleo.net/careersection/ex/jobsearch.ftl?lang=en)| Morrisville, NC | Data Science, API Development, Oracle EBS Technical and other positions are available. |
+|[Advance Auto Parts](https://www.advanceautoparts.jobs/en-US/search?keywords=2021&location=)| Raleigh, NC | Data Science, DevOps, IT Security positions are available. |
+|[OSI Group](https://osigroup.jobs.net/en-US/search?keywords=2021&location=)| Various | QA, Engineering positions are available. |
+|[Nokia](https://careers.nokia.com/jobs/search/25402806)| Various | Enablement Engineer, Data Science, Networking and other positions are available. |
+|[GEICO](https://geico.referrals.selectminds.com/jobs/technology-development-program-infrastructure-engineer-2021-11969/)| Chevy Chase, Maryland | Data Science, [Digital Experience (UX/UI)](https://geico.referrals.selectminds.com/jobs/digital-experience-ux-ui-internship-summer-2021-11980), Technology positions are available. GEICO conducts drug screens and background checks on applicants who accept employment offers. |
+|[Avalara](https://www.avalara.com/us/en/about/jobs/job-details.o07EdfwI.html)| Various | [Engineering positions](https://www.avalara.com/us/en/about/jobs/job-details.o07EdfwI.html) are available. Winter internships are available too. |
+|[Lenovo](https://lenovoworldwide.rolepoint.com/?shorturl=YJvM8#job/ahBzfnJvbGVwb2ludC1wcm9kchALEgNKb2IYgIDIu5zQ7gkM)| Morrisville, NC | Data Scince & Analytics, [Data Visualization](https://lenovoworldwide.rolepoint.com/?shorturl=YJvM8#job/ahBzfnJvbGVwb2ludC1wcm9kchALEgNKb2IYgIDI45yE-AgM), Workstation - Engineering and other positions are available. |
+|[Haven Life](https://boards.greenhouse.io/havenlife/jobs/4903938002)| New York, NY | [Full Stack Developer](https://boards.greenhouse.io/havenlife/jobs/4903938002) intern position is available. |
+[MagView Software Developer Intern](https://www.magview.com/software-developer-intern/) | Fulton, MD | intern position is available. |
+|[Vectra AI](https://www.vectra.ai/about/careers?gh_jid=851956)| CA , Boston | Data Science and Data Engineer internships |
+|[Niantic](https://boards.greenhouse.io/niantic/jobs/4905785002) | Remote | |
+|[SiriusXM](https://jobs.jobvite.com/careers/siriusxm/job/ojxEdfwr/apply) | Atlanta, Oakland, Dallas| |
+|[Khan Academy](https://boards.greenhouse.io/khanacademy/jobs/2369770)| US + Canada | |
+|[Rocket Central](https://www.myrocketcareer.com/ListJobs/JobTitle/2021)| Detroit, MI | System Engineer, Data Scientist, Data Analyst, Software Engineer and other positions are available. |
+|Hitachi ABB Power Grids| Various | **Closed** Various positions are available. All majors encouraged to apply. Candidate must already have a work authorization that would permit them to work for Hitachi ABB Power Grids in the United States. |
+|[U.S. Cellular](https://www.uscellular.jobs/search-results?keywords=2021)| Various | Infrastructure Engineering & Automation, Database Administration, Enterprise Security and other positions are available. |
+|[Tulip](https://tulip.co/careers/)| Somerville, MA | [Engineering Intern](https://tulip.co/careers/job-posting?gh_jid=4179163003) position is available. |
+|[Lumen Technologies](https://jobs.lumen.com/global/en/search-results?keywords=2021)| Various | [Software Developer](https://jobs.lumen.com/global/en/job/232875/Intern-Software-Developer-Summer-2021), [Software Engineer](https://jobs.lumen.com/global/en/job/233075/Intern-Software-Engineer-Summer-2021), [Network DevOps](https://jobs.lumen.com/global/en/job/232992/Intern-Network-DevOps-Summer-2021), [Information Security](https://jobs.lumen.com/global/en/job/233674/Intern-Information-Security-Summer-2021) and other positions are available. |
+|[Graco](https://phe.tbe.taleo.net/phe01/ats/careers/v2/searchResults?org=GRAC&cws=45)| Minneapolis, MN, Rogers, MN | Big Data Analytics, Computer Science, IT and other positions are available. |
+|Sandia National Laboratories| Various | **Closed** R&D Computer Science (Experienced), Cyber Security, Software Engineering and other positions are available. U.S. citizenship is required. Positions don't currently require a Department of Energy (DOE) security clearance. |
+|[UPS](https://www.jobs-ups.com/search-jobs/2021/United%20States/1187/1/2/6252001/39x76/-98x5/15/2)| Atlanta, GA | [Computer Science](https://www.jobs-ups.com/job/atlanta/ups-global-cs-interns-2021-kennesaw-state-univ/1187/17508589) internships are available. |
+|[Dairy Farmers of America](https://recruiting.adp.com/srccar/public/RTI.home?c=1104941&d=DFA)| Various | [WEB Development](https://recruiting.adp.com/srccar/public/RTI.home?c=1104941&d=DFA), [QA](https://recruiting.adp.com/srccar/public/RTI.home?c=1104941&d=DFA) positions are available. |
+|[PenFed Credit Union](https://penfed.dejobs.org/jobs/?q=2021)| McLean, Virginia | [IT](https://penfed.dejobs.org/mclean-va/it-intern-summer-2021/D6198D2D61D8468B8D2B592A18E379A6/job/), [Quantitative & Data Analytics](https://penfed.dejobs.org/mclean-va/quantitative-and-data-analytics-intern-summer-2021/0C1C9EA4403B4F969913C8F91D24483E/job/) positions are available. |
+|[Endurance International Group](https://careers.endurance.com/global/en/search-results?keywords=2021)| Waltham, MA | [Software Engineering](https://careers.endurance.com/global/en/job/2380402/Software-Engineering-Internship-Summer-2021) Internship positions are available. |
+|[TC Energy](https://jobs.tcenergy.com/search/?createNewAlert=false&q=2021&locationsearch=)| Houston, TX | [Computer Science/IT](https://jobs.tcenergy.com/job/Houston-May-2021-U_S_-Bachelor-of-Science-Student-Opportunities-%28Computer-ScienceIT%29-TX-77001/670886000/), opportunities are available. Legally entitled to work in the U.S. permanently without requiring sponsorship. |
+|[Fiserv](https://www.careers.fiserv.com/search-jobs/2021/1758/1)| Various | Data Science, Cyber, Infrastructure and other positions are available. Must possess unrestricted work authorization and not require future sponsorship. |
+|[Grant Thornton](http://jobs.grantthornton.com/2021-Cyber-jobs)| Various | [Cyber Security & Privacy](http://jobs.grantthornton.com/2021-Cyber-jobs) positions are available. |
+|McKesson| Various |**Closed** Software Developer, Software Engineer, Data Science, Machine Learning and other positions are available. No company sponsored housing, relocation, student visa or Green Card assistance available. |
+|[Barrick Gold Corporation](https://jobs.barrick.com/jobs/2021-summer-internship-it-and-computer-science-5716)| Elko Operations, Nevada | [IT and Computer Science](https://jobs.barrick.com/jobs/2021-summer-internship-it-and-computer-science-5716) positions are available. Must be able to pass Nevada Gold Mines’ pre-employment physical, which includes drug and alcohol testing as well as metals testing (where applicable). |
+|[SAS](https://globalcareers-sas.icims.com/jobs/search?ss=1&searchKeyword=2021&searchRelation=keyword_all)| North Carolina, Minnesota | Software Development, Software Quality Testing, IT, UX/UI and Systems Engineering positions are available. Applicants must be legally authorized to work in the United States, and should not require, now or in the future, sponsorship for employment visa status. |
+|[Vontier](https://careers.vontier.com/us/en/search-results?keywords=2021)| Various or possibly Remote | [Data Engineering](https://careers.vontier.com/us/en/job/GLO000185/Data-Engineering-Intern-Summer-2021), [Software Engineering](https://careers.vontier.com/us/en/job/GLO000184/Software-Engineering-Intern-Summer-2021), [Web Development](https://careers.vontier.com/us/en/job/MAT001986/Web-Developer-Intern-Co-Op-Spring-2021) positions are available. In-office work is preferred, but we are willing and able to accommodate remote internships if necessary. |
+|[Guardian Life](https://guardian.taleo.net/careersection/gl_ex/jobsearch.ftl)| Maybe remote or Westminster, CO | [Software Engineering](https://guardian.taleo.net/careersection/gl_ex/jobdetail.ftl?job=20001156&tz=GMT%2B03%3A00), [iOS Developer](https://guardian.taleo.net/careersection/gl_ex/jobdetail.ftl?job=20001155&tz=GMT%2B03%3A00), [API Developer](https://guardian.taleo.net/careersection/gl_ex/jobdetail.ftl?job=20001172&tz=GMT%2B03%3A00) and other positions are available. Applicants must be eligible to work in the U.S. without company sponsorship, now or in the future, for employment-based work authorization. |
+|[McCormick & Company](https://career4.successfactors.com/career?company=McCormick&career%5fns=job%5flisting%5fsummary&navBarLevel=JOB%5fSEARCH&_s.crb=2mJKMTL1WKEmDNfb7V%2b55ZdnQ8kvq2t4fHK9vGKoYPI%3d)| Hunt Valley, Maryland | [IT Internship - Business Transformation](https://career4.successfactors.com/career?career%5fns=job%5flisting&company=McCormick&navBarLevel=JOB%5fSEARCH&rcm%5fsite%5flocale=en%5fUS&career_job_req_id=86861&selected_lang=en_US&jobAlertController_jobAlertId=&jobAlertController_jobAlertName=&_s.crb=2mJKMTL1WKEmDNfb7V%2b55ZdnQ8kvq2t4fHK9vGKoYPI%3d), [IT Internship- Manufacturing Infrastructure & Applications](https://career4.successfactors.com/career?career%5fns=job%5flisting&company=McCormick&navBarLevel=JOB%5fSEARCH&rcm%5fsite%5flocale=en%5fUS&career_job_req_id=86841&selected_lang=en_US&jobAlertController_jobAlertId=&jobAlertController_jobAlertName=&_s.crb=2mJKMTL1WKEmDNfb7V%2b55ZdnQ8kvq2t4fHK9vGKoYPI%3d) positions are available. |
+|Formlabs| Somerville, MA | **Closed** Embedded Software, UI Software, Desktop Software. |
+|[Quip](https://salesforce.wd1.myworkdayjobs.com/en-US/External_Career_Site/job/California---San-Francisco/Summer-2021-Intern---Software-Engineer--Quip-_JR73678) | SF | |
+|Sofi| SF, Seattle, Utah | **Closed** | 
+|[CSG](https://careers.csgi.com/)| Omaha, Nebraska | [Software Development Intern](https://careers.csgi.com/job/CSINUS18095/Software-Development-Intern-Summer-2021), [Corporate IT](https://careers.csgi.com/job/CSINUS18125/Corporate-IT-Intern-Summer-2021), [IT](https://careers.csgi.com/job/CSINUS18090/IT-Intern-Summer-2021) and other positions are available. |
+|[DISTek Integration, Inc.](https://www.distek.com/careers/)| Des Moines, Cedar Falls, and Dubuque, Iowa | |
+|GoHealth| Chicago, IL | **Closed** Tech (software engineering, data analytics/science, IT, QA) positions are available. |
+|[Censys](https://boards.greenhouse.io/censys/jobs/4906773002)| Ann Arbor, Michigan | Engineering Internship positions are available. |
+|[Crown Equipment Corporation](https://us-careers.crown.com/job/New-Bremen-Software-Development-Co-Op-Summer-2021-OH-45869/681725500/)| New Bremen, OH | [Software Development](https://us-careers.crown.com/job/New-Bremen-Software-Development-Co-Op-Summer-2021-OH-45869/681725500/) Internship positions are available. Crown will only employ those who are legally authorized to work in the United States |
+|[AIR Worldwide](https://careers.smartrecruiters.com/Verisk/air)| Boston, MA | [Cyber Security](https://jobs.smartrecruiters.com/Verisk/743999721391994-cyber-security-intern-2021-summer-internship-program-cr?trid=bc116d3b-429c-40ba-8299-6faab749b9dd) Intern positions are available. The Intern Program is not eligible for work visa sponsorship. |
+|[Battelle](https://group1.applicantpro.com/jobs/1537030.html)| Columbus, OH, Egg Harbor Township, NJ, Chantilly, VA | [Software Engineering](https://jobs.battelle.org/ShowJob/JobId/2610273/SoftwareEngineeringFrontEndInternSummer2021), [Data Science](https://jobs.battelle.org/ShowJob/JobId/2610290/DataScienceInternSummer2021), [Medical Devices Software Engineering](https://jobs.battelle.org/ShowJob/JobId/2639638/MedicalDevicesSoftwareEngineeringCoopSpring2021) and other positions are available. Must be US Person. |
+|[City National Bank](https://careers.cnb.com/job/los-angeles/2021-summer-internship-program-data-analytics-data-science/1557/1727369280)| Los Angeles, CA | [Data Analytics/Data Science](https://careers.cnb.com/job/los-angeles/2021-summer-internship-program-data-analytics-data-science/1557/1727369280) position is available. |
+|[Credit Karma](https://www.creditkarma.com/careers/jobs/university/software-engineering-intern-2021)| Charlotte, NC | [Software Engineering](https://www.creditkarma.com/careers/jobs/university/software-engineering-intern-2021) Intern position is available. |
+|[Carrier](https://jobs.carrier.com/search-jobs/2021)| Pittsford, Syracuse, New York | [Web/UI Video Software Development](https://jobs.carrier.com/job/pittsford/web-ui-video-software-development-engineer-spring-2021-co-op/29289/17087511), [Engineering](https://jobs.carrier.com/job/syracuse/engineering-intern-co-op/29289/17570372), [DevOps](https://jobs.carrier.com/job/pittsford/devops-engineer-spring-2021-co-op/29289/17114509) and other positions are available. |
+|[Booz Allen](https://careers.boozallen.com/careers/JobDetail/Annapolis-Junction-Data-Science-Intern-R0091880/31448?uid=5FioJR6DtYxLDT2g)| Annapolis Junction, MD | [Data Science](https://careers.boozallen.com/careers/JobDetail/Annapolis-Junction-Data-Science-Intern-R0091880/31448?uid=5FioJR6DtYxLDT2g) Internship position is available. Ability to obtain a security clearance required. | 
+|[Kellogg's](https://kelloggs.taleo.net/careersection/2/jobdetail.ftl?job=INF001571)| Battle Creek, MI ; Oak Brook, IL | |
+|athenahealth| Watertown, MA; Austin, TX | **Closed** Data Science/AI, Engineering positions and other positions are available. |
+|[Georgia Tech Research Institute](https://careers.gtri.gatech.edu/en-us/search/?search-keyword=2021)| Atlanta, GA; Smyrna, GA | Electronic Systems Integration, [Security Research](https://careers.gtri.gatech.edu/en-us/job/495963/security-research-student-intern-summer-2021-cipher), Aircraft Protection Systems and other positions are available. Due to our research contracts with the US federal government, candidates for this position are required to be US Citizens. Spring 2021 positions are available. |
+|[Marathon Petroleum Corporation](https://jobs.marathonpetroleum.com/job/Various-InternCo-op-Information-Technology-%282020-2021%29-Vari/667326000/) | Various | Business Analyst, Infrastructure Engineer, Applications Developer positions are available. Candidates must be authorized to work in the US on a full-time indefinite basis without the need for employment visa sponsorship now or in the future. Positions are available spring, summer, and fall semesters. |
+|[Innovative Systems](http://careers.innovativesystems.com/)| Pittsburgh, PA | [Software Engineering & Development](http://innovativesystems.applytojob.com/apply/yTR8zCvIBi/InternCoop-Software-Engineering-Development-Summer-2021), [Operations Rotation](http://innovativesystems.applytojob.com/apply/wpevsVGqVr/InternCoop-Operations-Rotation-Summer-2021) positions are available. Spring internships are available too. |
+|gsk| King of Prussia, PA; Rockville, MD | **Closed** Digital Engineering Future Leaders Program (Rotational): Project Management, Automation, Data Science, Cyber security. Mobile and willing to relocate domestically. |
+|[Amgen](https://careers.amgen.com/career-search/?keyword=2021)| Tampa, FL; Thousand Oaks, CA | Software Engineer, Data Science, Business Analyst positions are available. |
+|Blue Yonder| Scottsdale, AZ; Dallas, TX | **Closed** |
+|[PactSafe](https://pactsafe-inc.breezy.hr/p/a9aa7bcdd706-software-engineer-summer-2021-intern)| Indianapolis, IN | [Software Engineering](https://pactsafe-inc.breezy.hr/p/a9aa7bcdd706-software-engineer-summer-2021-intern) Intern position is available. |
+|3M| Maplewood, MN |**Closed** IT, Data Sciencepositions are available. 3M provides eligible interns with temporary housing and round-trip travel reimbursement in accordance with current policy. Must be legally authorized to work in country of employment without sponsorship for employment visa status (e.g., H1B status). |
+|MFS Investment Management| Boston, MA | **Closed** |
+|[FlatIron Health](https://flatiron.com/careers/open-positions/2263862) | NYC | |
+|[PetSmart](https://careers.petsmart.com/student-interns/jobs?keywords=Software&page=1&sortBy=relevance&categories=Students) | Phoenix, Arizona | [IT Engineering Internship](https://careers.petsmart.com/student-interns/jobs/2162?lang=en-us) and [IT Analyst Internship](https://careers.petsmart.com/student-interns/jobs/2163?lang=en-us) available. |
+|BP| Chicago, Illinois; Houston, Texas | **Closed** |
+|Xylem| Atlanta, GA; Morrisville, NC (RTP) | **Closed** Software Engineer, Data Science, Firmware Engineer Intern positions are available. |
+|Northwestern Memorial Hospital| Chicago, IL | **Closed** Analytics, IT Internship positions are available. Network, Converged Infrastructure, Software Development and other specializations are available. |
+|[DuPont](https://careers.dupont.com/us/en/search-results?m=3&keywords=2021)| Wilmington, DE | [IT](https://careers.dupont.com/us/en/job/DUPOUSLIM00001092EXTERNALENUS/2021-Information-Technology-Internship-Program) Intern postion is available. Roles in Information Security, Enterprise Service Delivery, Enterprise Application Services, Digital Solutions, End User Experience, and Strategy & Communications. Have the right to work in the U.S. without restriction. |
+|[Piper Sandler](https://chu.tbe.taleo.net/chu04/ats/careers/v2/searchResults?org=PIPER_SANDLER&cws=44)| Minneapolis, MN | [Information Security](https://chu.tbe.taleo.net/chu04/ats/careers/v2/viewRequisition?org=PIPER_SANDLER&cws=44&rid=2604), [Data Integration and Management](https://chu.tbe.taleo.net/chu04/ats/careers/v2/viewRequisition?org=PIPER_SANDLER&cws=44&rid=2593), [Web Development](https://chu.tbe.taleo.net/chu04/ats/careers/v2/viewRequisition?org=PIPER_SANDLER&cws=44&rid=2612) and other positions are available. |
+|[FIS](https://careers.fisglobal.com/us/en/search-results?keywords=2021)| Lowell, MA; Saint Petersburg, Jacksonville, FL; Cincinnati, OH and others | [Data Science](https://careers.fisglobal.com/us/en/job/JR0123271/Intern-Data-Science-Summer-Associate-Development-Program-2021), [Technologist Engineer](https://careers.fisglobal.com/us/en/job/JR0123188/Intern-Technologist-Engineer-I-Associate-Development-Program-2021), [Software Engineer](https://careers.fisglobal.com/us/en/job/JR0122659/Intern-Software-Engineer-Associate-Development-Program-2021) and other positions are available. If you are made a conditional offer of employment, you will be required to undergo a drug test. Some roles don't provide sponsorship now or in the future. |
+|Siemens| Charlotte, NC; others | **Closed** |
+|[FirstEnergy](https://careers.firstenergycorp.com/search/?q=2021&utm_source=CSSearchWidget&startrow=1)| Akron, OH; Wadsworth, OH | [IT Network](https://careers.firstenergycorp.com/job/Akron-IT-Network-Intern-Summer-2021-OH-44320/678585800/), [IT Software Development](https://careers.firstenergycorp.com/job/Akron-IT-Software-Development-Intern-Summer-2021-OH-44320/675734800/), [IT Cyber Compliance Policy](https://careers.firstenergycorp.com/job/Wadsworth-Cyber-Compliance-Policy-Analyst-Co-OpIntern-Summer-2021-OH-44281/678028800/) and other positions are available. |
+|[Kiewit](https://kiewitcareers.kiewit.com/search/?q=2021&q2=&alertId=&locationsearch=&title=Summer+2021&shifttype=&department=&location=US)| Omaha, NE | [Software Engineer](https://kiewitcareers.kiewit.com/job/Omaha-Software-Engineer-Intern-Kiewit-Technology-Group-NE-68046/675934800/) Intern position is available. |
+|[Perspecta](https://careers.perspecta.com/jobs?keywords=2021&page=1)| Silver Spring, MD; Basking Ridge, NJ | [Cyber](https://careers.perspecta.com/jobs/101311?lang=en-us) Internship positions are available. U.S. Citizens strongly preferred - permanent residents may be considered if highly qualified. |
+|[Bristol Myers Squibb](https://www.bms.com/ca/en/job-seekers/job-search-results.html?country=united%20states%20of%20america&category=intern/co-op/student/flex&keyword=2021&page=1)| Tampa, FL | [Cloud Operations Engineering](https://www.bms.com/ca/en/job-seekers/job-search-results/job-details.html?requisitionId=R1529838), [Data Science](https://www.bms.com/ca/en/job-seekers/job-search-results/job-details.html?requisitionId=R1529835) positions are available. Candidates must be available to be onsite at the BMS- Tampa, FL location for the year internship. |
+|[L'Oréal](https://careers.loreal.com/en_US/jobs/JobDetail/2021-L-Oreal-USA-Summer-Internship-Information-Technology-Undergraduate/89141?source=Indeed)| New York, NY | Information Technology Undergraduate, applications close Friday, December 4, 2020. Legally authorized to work in the US on a fulltime, permanent, and ongoing basis without requiring sponsorship now or in the future. |
+|[U.S. Bank](https://usbank.taleo.net/careersection/10000/jobsearch.ftl?lang=en&keyword=2021%20undergraduate%20summer%20internship%20technology) | Various | Software Development, Data Analytics, Digital Engagement, Business Analyst, and other positions are available. |
+|[Comcast](https://jobs.comcast.com/jobs/description/regular?job_id=221340&external_or_internal=external) | Atlanta, GA | Machine Learning, Information Security, Application Development Internship positions are available. Must be authorized to work in the USA. |
+|[Abbott](https://www.jobs.abbott/us/en/search-results?keywords=2021)| Various | [Computer Science and Engineering](https://www.jobs.abbott/us/en/job/30960426/2021-Engineering-Co-op), [IT](https://www.jobs.abbott/us/en/job/30956533/2021-IT-Intern), [Data Science](https://www.jobs.abbott/us/en/job/30957183/Abbott-Nutrition-Data-Science-Internship-Summer-2021) Intern positions are available. Students must be able to work in the US without requiring sponsorship. |
+|[Hologic](https://hologic.referrals.selectminds.com/jobs/search/1671852)| Various | [Engineering](https://hologic.referrals.selectminds.com/jobs/summer-2021-engineering-internship-opportunities-3822), [Information Services](https://hologic.referrals.selectminds.com/jobs/summer-2021-information-services-internship-opportunities-3826) Intern positions are available. |
+|[Cigna](https://jobs.cigna.com/us/en/job/20014206/Technology-Early-Career-Development-Program-TECDP-2021-Full-Time-Associate)| Bloomfield, CT; St. Louis, MO; Philadelphia, PA; Denver, CO; Franklin Lakes, NJ; Nashville, TN ; Eden Prairie; Minneapolis/Bloomington, MN; NYC, NY | Application Developer, Data Analyst, Network Engineer and other positions are available. This position is open only to individuals who are eligible for employment in the United States and who would not require visa sponsorship now or in the future. |
+|[E. & J. Gallo Winery](https://careers.gallo.com/search/?q=2021&q2=&alertId=&locationsearch=&title=2021&location=)| Modesto, CA | [Data Analyst/Scientist](https://careers.gallo.com/job/Modesto-DA-Intern-2021-3-months-CA-95354/670380000/), [Business System Analyst](https://careers.gallo.com/job/Modesto-BSA-Intern-2021-3-months-CA-95354/670378700/) Intern positions are available. Gallo does not sponsor for employment based visas for this position now or in the future. |
+|[Duquesne Light Company](https://career4.successfactors.com/career?career%5fns=job%5flisting&company=Duquesne&navBarLevel=JOB%5fSEARCH&rcm%5fsite%5flocale=en%5fUS&career_job_req_id=12880&selected_lang=en_US&jobAlertController_jobAlertId=&jobAlertController_jobAlertName=&_s.crb=7TmQE6vsBa1F4rZpkPGieRGoItHHMjLdyAZfIX4e%2bz8%3d)| Pittsburgh, PA | Software Engineer, Systems Analyst, Information Security Analyst (Cyber Security Operations) and other intern positions are available. |
+|Cubic| Boston, MA | **Closed** Software Engineering Intern |
+|[Hubbell Incorporated](https://careers.hubbell.com/search/?createNewAlert=false&q=2021&locationsearch=&optionsFacetsDD_country=&optionsFacetsDD_state=)| Christiansburg, VA; Austin, TX | [Industrial Engineering/Computer Science](https://careers.hubbell.com/job/Christiansburg-Industrial-EngineeringComputer-Science-Intern-%28Summer-2021%29-Christiansburg%2C-VA-VA-24073/674989300/), [Computer Science/Electrical Engineering](https://careers.hubbell.com/job/Austin-Computer-ScienceElectrical-Engineering-Intern-%28Summer-2021%29-Austin%2C-TX-TX-78754/674992400/) Intern positions are available. |
+|[ITW](https://careers.itw.com/job-search.html)| Glenview, IL | [IT Cyber Security](https://www.smartrecruiters.com/ITW/743999719214439-it-cyber-security-intern-summer-2021), [IT Business Analyst](https://www.smartrecruiters.com/ITW/743999719214614-it-business-solutions-analyst-intern-summer-2021), [Service Desk Analyst](https://www.smartrecruiters.com/ITW/743999719220270-service-desk-analyst-intern-summer-2021) and other Intern positions are available. ITW Audit Department is not currently hiring individuals for this position who now or in the future require sponsorship for employment visa status. |
+|[Micro Focus](https://jobs.microfocus.com/global/en/search-results?m=3&keywords=2021)| Various/Remote Eligible | [DevOps](https://jobs.microfocus.com/global/en/job/7016242/DevOps-Intern-Summer-2021-Vertica-US-REMOTE), [QA Test](https://jobs.microfocus.com/global/en/job/7016241/Quality-Assurance-Test-Intern-for-SUMMER-2021-Vertica-US-REMOTE) Intern positions are available. |
+|[Post Consumer Brands](https://jobs.postconsumerbrands.com/search-jobs/2021/1980/1)| Lakeville, MN | [IT Network Administration - Infrastructure](https://jobs.postconsumerbrands.com/job/lakeville/it-intern-network-administration-infrastructure-lakeville-mn-summer-2021/1980/1257783808), [IT Project Management](https://jobs.postconsumerbrands.com/job/lakeville/it-project-management-intern-lakeville-mn-summer-2021/1980/1055554960) Intern positions are available. |
+|[State Farm](https://findjobs.statefarm.com/Listjobs/All/search/keyword/Intern)| Champaign, IL; Athens, GA | [Technology Rotational (RDC)](https://findjobs.statefarm.com/ShowJob/JobId/458399/InternTechnologyRDCSummer2021), [Intern - ED&A- Pre-MAGNet Program @ University of Georgia](https://findjobs.statefarm.com/ShowJob/JobId/465285/InternEDAPreMAGNetProgramUniversityofGeorgiaSummer2021) Intern positions are available. |
+|Vistaprint | Boston, MA | **Closed** |
+[Atlassian](https://www.atlassian.com/company/careers/all-jobs?team=&location=&search=2021)| San Francisco, NYC, Mountain View, Austin, Remotely | [Frontend Software Engineer](https://www.atlassian.com/company/careers/detail/ca928061-7c96-424d-b1ac-c9fdccdd7524), [Software Engineer](https://www.atlassian.com/company/careers/detail/ab59a0cd-c07d-4daf-8d9e-d5dd340308f4) Intern positions are available. Not eligible for Visa sponsorship. Unfortunately, we do not offer U.S. work visa sponsorship to F-1 or J-1 students at this time. |
+| United Health Group | Various Locations | **Closed** Technology Development Internship |
+|[Florida Blue](https://careers.floridablue.com/us/en/job/22240/2021-IT-Summer-Internship-Program)| Remote, United States | Infrastructure; Front End Design, Development, and Innovation; Cybersecurity; Application Development; Data Science/Analytics Intern positions are available. |
+|[Avient Corporation](https://polyone.referrals.selectminds.com/jobs/it-intern-2021-2471)| Avon Lake, Ohio | |
+|[Unum](https://unum.wd1.myworkdayjobs.com/en-US/External/job/USA---TN---Chattanooga/IT-Summer-Internship-2021_816555-1)| Chattanooga, TN; Portland, ME; Atlanta, GA; Columbia, SC | |
+|[PathAI](https://www.pathai.com/careers/?gh_jid=4851472002)| Boston, MA | Machine Learning Internship position is available. |
+|[LinkedIn](https://www.linkedin.com/jobs/view/2184303072/) | Sunnyvale | |
+|Commerce Bank| Kansas City, MO | **Closed** Interns must be eligible to work in the United States without sponsorship. |
+|[The Andersons](https://andersonsinc.wd1.myworkdayjobs.com/en-US/TheAndersonsCareers/job/Maumee-OH/Intern--Office--IT-Security--Summer-2021-_R6769)| Maumee, OH | IT Security Intern position is available. |
+|[Equitable](https://equitable.taleo.net/careersection/eqh_1/jobdetail.ftl?job=200004DE&tz=GMT%2B03%3A00&tzname=Europe%2FVilnius)| Charlotte, NC | |
+|[Micron Technology](https://jobs.micron.com/search/?createNewAlert=false&q=2021&locationsearch=US)| Various | [IT Software Engineer](https://jobs.micron.com/job/Boise-Intern-IT-Software-Engineer-1-ID-83701/669629700/), [Data Science](https://jobs.micron.com/job/Boise-Intern-Data-Science-%28Summer-2021%29-ID-83701/675266600/), [IT Full Stack Software Engineer](https://jobs.micron.com/job/Boise-Intern-IT-Full-Stack-Software-Engineer-ID-83701/670310800/) and other Intern positions are available. |
+|[Clever](https://clever.com/about/careers/software-engineering-internship)| San Francisco, CA; Durham, NC or Remote anywhere in the Continental U.S. | |
+|[Ridgeline](https://boards.greenhouse.io/ridgeline/jobs/4126398003) | Incline Village, NV | |
+|[Cruise](https://boards.greenhouse.io/cruise/jobs/2365741?gh_jid=2365741) | SF | Other [internships](https://www.getcruise.com/careers/jobs?department=2bGFusPlaxpzEPHPIb2QLK) as well|
+|[Confluent](https://jobs.lever.co/confluent/17c08395-28cd-4737-9db6-452bab4720be/apply) | Mountain View | [Front end](https://jobs.lever.co/confluent/7dfa6977-59d6-4c00-9c52-b27d2ce8a001) |
+| [Mark 43](https://www.mark43.com/list-job/?gh_jid=1335587&gh_src=da71ca841) | New York, NY; Toronto, ON | [Toronto](https://www.mark43.com/list-job/?gh_jid=1335584). Not sponsering J-1 or F-1 visas for NY location this summer. |
+| [Motional](https://motional.com/careers/) | Pittsburgh, PA | |
+| [Kitu Systems](https://www.linkedin.com/jobs/view/2192517109/?eBP=JOB_SEARCH_ORGANIC&refId=9f47083c-64ed-4a2f-b349-f0c5a1506f2f&trackingId=l5MFx6scK0aPtuzjltsi7w%3D%3D&trk=flagship3_search_srp_jobs) | Irvine, CA | Apply through third party site |
+| [Bubble](https://boards.greenhouse.io/bubble/jobs/4806477002) | New York, NY | Currently remote |
+| [Bohemia Interative Simulations](https://apply.workable.com/bohemia-interactive-simulations-inc/j/3822C827D7/) | Pittsburgh, PA | |
+| Nuance | Burlington, Massachusetts | **Closed** | 
+| [PSEG](https://jobs.pseg.com/search/?createNewAlert=false&q=2021&locationsearch=)| Salem, Newark, Hancocks Bridge, NJ | Infrastructure Project, Application Support, Cybersecurity, Software Development and other positions are available. |
+| [Michael Foods](https://jobs.postholdings.com/search-jobs?k=2021&ascf=[{%27key%27:%27company_name%27,%27value%27:%27Michael%20Foods%27}])| Minnetonka, Gaylord, Minnesota | [IT Business Intelligence](https://jobs.postholdings.com/job/minnetonka/it-business-intelligence-internship-summer-2021/8462/1385263808), [IT Support Analyst](https://jobs.postholdings.com/job/minnetonka/it-support-analyst-internship-summer-2021/8462/1385263616), [IT CyberSecurity Administrator](https://jobs.postholdings.com/job/minnetonka/it-cybersecurity-administrator-internship-summer-2021/8462/1385263552) and other Intern positions are available. |
+| [Novartis Gene Therapies (Avexis)](https://www.avexis.com/us/careers.html#)| Illinois, Colorado | [IT - Colorado](https://careers-avexis.icims.com/jobs/5544/internship%2c-information-technology-%28colorado%29/job?in_iframe=1), [IT - Illinois](https://careers-avexis.icims.com/jobs/5543/internship%2c-information-technology-%28illinois%29/job?in_iframe=1) Intern positions are available. |
+| [Virgin Galactic](https://careers-virgingalactic.icims.com/jobs/search?ss=1&searchKeyword=2021)| Las Cruces, NM; Mojave, CA | [Internship - Various Teams](https://careers-virgingalactic.icims.com/jobs/6006/internship-various-teams---summer-2021/job?in_iframe=1). Applicant must be a U.S. citizen, lawful permanent resident of the U.S., protected individual as defined by ITAR (22 CFR §120.15) or eligible to obtain the required authorizations from the U.S. Department of State. |
+| [NI (National Instruments)](https://pef.fa.us1.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX/requisitions/preview/1240/?keyword=2021)| Austin, TX | NI does NOT petition for H-1B status from student visas for full-time or intern hires, thus cannot accept candidates for this position who are on a student visa and have Curriculum Practical Training (CPT), Optional Practical Training (OPT), or academic training. |
+| Aurora | Palo Alto, SF, Pittsburgh | **Closed** |
+|[Lark Health](https://boards.greenhouse.io/larkhealth)| Mountain View, CA | [Data Analyst](https://boards.greenhouse.io/larkhealth/jobs/4891889002), [Backend Engineer](https://boards.greenhouse.io/larkhealth/jobs/4891818002), [Mobile Engineer](https://boards.greenhouse.io/larkhealth/jobs/4891825002) and other Intern positions are available. |
+|Speedway Motors| Lincoln, NE | Closed |
+|United Airlines| Chicago, IL | **Closed** Must be legally authorized to work in the United States for any employer without sponsorship. |
+|Lytx| San Diego, CA | **Closed**  |
+|Ingredion| Westchester, IL | **Closed**  |
+|[Adidas](https://careers.adidas-group.com/teams/students/internships-students#2021-portland-internships)| Portland, OR | Application process opens: January. All candidates must be legally eligible to work in the US for the entire duration of the internship. |
+|[Best Buy](https://sjobs.brassring.com/TGnewUI/Search/Home/Home?partnerid=25632&siteid=5798#keyWordSearch=intern&locationSearch=&Job%20Category=Digital%20&%20Information%20Technology)| Seattle, WA; Richfield, MN | Must be eligible to work in the U.S. without company sponsorship, now or in the future, for employment-based work authorization (F-1 students with practical training and candidates requiring H-1Bs, TNs, etc. will not be considered). |
+|General Atomics| San Diego, CA | **Closed** |
+|[CalAmp](https://careers-calamp.icims.com/jobs/search?ss=1&searchKeyword=2021)| Eden Prairie, MN; Irvine, Carlsbad CA; | [Firmware Engineer](https://careers-calamp.icims.com/jobs/3143/intern%2c-engineer-firmware---eden-prairie%2c-mn-%28summer-202%601%29/job?in_iframe=1), [IT Security](https://careers-calamp.icims.com/jobs/3148/intern%2c-it-security---irvine%2c-ca-%28summer-2021%29/job?in_iframe=1), [Test and Validation Engineer](https://careers-calamp.icims.com/jobs/3172/intern%2c-engineer-test-and-validation---carlsbad%2c-ca-%28summer-2021%29/job?in_iframe=1) and other Intern positions are available. |
+|[Baird](https://bairdcareers.com/career-search/?keyword=2021&zip=&distance=20.0&country=United%20States%20of%20America&state=&office=&career_areas=&spage=1)| Milwaukee, WI | [Compliance Data Analytics](https://bairdcareers.com/career-search/posting/internship---compliance-data-analytics-year-round-immediate-start-/8270BR), [IT Software Developer](https://bairdcareers.com/career-search/posting/internship---it-software-developer-year-round-/8220BR), [IT Service Desk](https://bairdcareers.com/career-search/posting/internship---it-service-desk-year-round-/8218BR/) and other Intern positions are available. |
+|[Zurich North America](https://zurich.taleo.net/careersection/zurich_ext_zna_en/jobsearch.ftl?lang=en&radiusType=K&location=14970752267&searchExpanded=true&radius=1&portal=8270752267)| Schaumburg, IL | [IT Test Automation](https://zurich.taleo.net/careersection/zurich_ext_cs/jobdetail.ftl?job=200004IH&tz=GMT%2B03%3A00), [Data Science](https://zurich.taleo.net/careersection/zurich_ext_cs/jobdetail.ftl?job=200004UZ&tz=GMT%2B03%3A00), [Data Management](https://zurich.taleo.net/careersection/zurich_ext_cs/jobdetail.ftl?job=200004HW&tz=GMT%2B03%3A00) Intern positions are available. Must be legally eligible to work in the U.S indefinitely. |
+|[Amcor](https://www.amcor.com/careers/job-search?keyword=2021)| Oshkosh, WI | We verify the identity and employment authorization of individuals hired for employment in the United States. |
+|[Braze](https://boards.greenhouse.io/braze/jobs/840086?gh_jid=840086) | NY | |
+|[AffiniPay](https://recruitingbypaycor.com/career/JobIntroduction.action?clientId=8a7883c6640b53f8016413af17602f6a&id=8a78879e6d98ce17016da76b9cd734f5&source=&lang=en) | Austin, TX | |
+|[Owens Corning](https://jobs.owenscorning.com/job/toledo/information-services-intern-2021/868/17170060)| Toledo, OH | |
+|[Lincoln Financial Group](https://jobs.lincolnfinancial.com/search/?q=2021)| Various | |
+|[Meijer](https://meijer.wd5.myworkdayjobs.com/Meijer/0/refreshFacet/318c8bb6f553100021d223d9780d30be)| Grand Rapids, MI | |
+|[Pella Corporation](https://careers.pella.com/jobs/information-technology-intern-summer-2021-2975) | Pella, IA | |
+|[Zendesk](https://jobs.zendesk.com/us/en/job/R13853/Software-Development-Intern) | California, [Wisconsin](https://jobs.zendesk.com/us/en/job/R13868/Software-Development-Intern) | |
+|[Mailchimp](https://boards.greenhouse.io/mailchimp/jobs/2331177) | Atlanta | |
+[Prifina](https://roadmaptalent.com/jobs/prifina-software-engineering-intern/) | New York, NY | Remote Internship |
+|[WW (formerly Weight Watchers)](https://www.weightwatchers.com/us/corporate-careers?p=jobs%2F)| New York; San Francisco, CA | Software Engineering, Mobile Engineering, Data Science and other Intern positions are available. |
+|[Rock Central](https://www.myrocketcareer.com/ListJobs/JobTitle/2021)| Detroit, MI | |
+|[MUFG](https://jobs.mufgamericas.com/search-jobs/2021/29757-30166/1)| Tempe, AZ; Charlotte, NC; Dallas, TX | You are able to furnish proof of citizenship, permanent residency or work in the U.S. |
+|[The Climate Corporation](https://climate.eightfold.ai/careers?pid=2038576&query=2021&domain=climate.com)| San Francisco, CA; Seattle, WA; St. Louis, MO; Chicago, IL | |
+|[CAS](https://jobs.acs.org/search/?createNewAlert=false&q=2021&locationsearch=)| Columbus, OH | Candidates for this position must be authorized to work in the United States and not require work authorization sponsorship by our company for this position now or in the future. |
+|[Charles Schwab](https://career-schwab.icims.com/jobs/search?ss=1&searchKeyword=2021&searchRelation=keyword_all)| Austin, Westlake TX; Phoenix, AZ; Chicago, IL; San Francisco, CA; Raleigh, NC | |
+|General Dynamics Information Technology| Falls Church, VA; Shreveport/Bossier City, LA; Washington, D.C; Rockville, Annapolis Junction MD; San Antonio, TX | **Closed** Currently pursuing an Associate’s, Bachelor’s or Master’s degree from a United States-based college or university with an IT related major. |
+|[Phillips 66](https://phillips66.jobs/jobs/?q=2021)| Various | Legally authorized to work in the job posting country. |
+|[RubensteinTech](https://rubensteintech.applytojob.com/apply/LHjGXtPEzd/Web-Software-Engineering-Intern-Summer-2021)| New York, NY | |
+|[Staples](https://careers.staples.com/ShowJob/JobId/986154/CybersecurityInternshipSummer2021)| Framingham, MA | Cybersecurity Intern position is available. Staples will not sponsor candidates for work visas of any kind, now or in the future, for this position. |
+|[Unity](https://careers.unity.com/university) | SF | |
+|Nintendo| Redmond, WA | **Closed** Other intern positions avaialable |
+|[Esri](https://www.esri.com/en-us/about/careers/job-search?q=2021)| Various | [IT](https://www.esri.com/careers/information-technology-2021-internships-13005), [Software Development and Engineering](https://www.esri.com/careers/software-development-and-engineering-2021-internships-13003) Intern positions are available. Must have ability to obtain work authorization in the United States in 2021. |
+|[CAS](https://jobs.acs.org/search/?createNewAlert=false&q=2021&locationsearch=)| Columbus, OH | [Technology](https://jobs.acs.org/job/Columbus-Technology-Intern-Summer-2021-OH-43202/679619000/), [DAI](https://jobs.acs.org/job/Columbus-DAI-Intern-OH-43202/680119500/) Intern positions are available. Candidates for this position must be authorized to work in the United States and not require work authorization sponsorship by our company for this position now or in the future. |
+|[Matco Tools](https://careers.vontier.com/us/en/search-results?keywords=2021)| Various | [Web Developer](https://careers.vontier.com/us/en/job/MAT001987/Web-Developer-Intern-Co-Op-Summer-2021), [Firmware Engineer](https://careers.vontier.com/us/en/job/GLO000187/Firmware-Engineering-Intern-Summer-2021), [Software Engineering](https://careers.vontier.com/us/en/job/GLO000184/Software-Engineering-Intern-Summer-2021) Intern positions are available. |
+|[InfluxData](https://www.influxdata.com/careers/)| Remote | |
+|[Carnegie Robotics](https://carnegierobotics.com/hiring)| Pittsburgh, PA | |
+|[Electronic Arts](https://www.ea.com/careers/students) | Redwood City, CA; Austin, TX; Orlando, FL; Seattle, WA; Los Angeles, CA | |
+|[Disney](https://jobs.disneycareers.com/search-jobs/2021?orgIds=391-27721-28802-28648-28833-28834-28840-28843-28842-28841-28851&kt=1&afc=26715) | Remote (USA) | [Software Engineering Intern](https://jobs.disneycareers.com/job/united-states/software-engineering-intern-remote-summer-2021/391/18763472?cid=19883&ck_subscriber_id=1030949092&utm_source=convertkit&utm_medium=email&utm_campaign=Student+Edition+Issue+%2313%20-%205306209)|
+|[Deutsche Bank](https://www.db.com/careers/en/grad/role-search/job_search_results.html#career_level=11) | New York, NY; Cary, NC | Some positions will not provide sponsorship for work visa. |
+|[HackNY](https://hackny.org/fellows-program)|New York City, NY | |
+|[PepsiCo](https://www.pepsicojobs.com/student/jobs/213146BR?lang=en-us) | Plano, TX; Purchase/White Plains, NY | Project Coordination, Development, Data Analytics, Business Analyst, and Information Security positions are available. Must have the "indefinite right to work in the United States." Not Eligible for Relocation. |
+|[Mutual of Omaha](https://www.mutualofomaha.com/careers/jobs/detail/497505)| Omaha, NE | Closes November 4th. |
+|[CBRE](https://cbre.referrals.selectminds.com/jobs/software-engineer-intern-78131?src=JB-10160)| Dallas, Texas | Software Engineer Intern |
+|[Restaurant Brands International](https://boards.greenhouse.io/rbicampus/)| Miami, FL | [Software Engineering](https://boards.greenhouse.io/rbicampus/jobs/4844891002), [Machine Learning](https://boards.greenhouse.io/rbicampus/jobs/4844875002) and other Intern positions are available. |
+|[OppLoans](https://www.opploans.com/careers/#joblisting) | Chicago, IL | Various tracks are available. |
+|[Baker Hughes](https://careers.bakerhughes.com/global/en/search-results?keywords=2021)| Houston, TX | Must be geographically mobile due to location availability of role. Must be able to legally work in the country that you are applying in, without company sponsorship or time restriction. |
+|PerBlue | Madison, Wisconson | **Closed** |
+|[Sabre Corporation](https://jobs.sabre.com/search/?createNewAlert=false&q=2021&locationsearch=&optionsFacetsDD_title=&optionsFacetsDD_location=&optionsFacetsDD_department=)| Southlake, TX | [Software Engineer](https://jobs.sabre.com/job/Southlake-Software-Engineer-Intern-Summer-2021-TX-75063/688127700/), [UX Strategy](https://jobs.sabre.com/job/Southlake-Contributor-Intern-TX-Refer-to-j/685692700/), [UX Research](https://jobs.sabre.com/job/Southlake-UX-Research-Intern-2021-Summer-TX-75063/687556000/) Intern positions are available. |
+|[QGenda](https://qgenda.applytojob.com/apply/v4bYdyojr5/Software-Engineer-Internship-Spring-2021)| Atlanta, GA | Software Engineer Intern |
+|[Brain Corp](https://www.braincorp.com/company/careers/)| San Diego, CA | [Embedded Software Engineer](https://www.braincorp.com/company/careers/job/?id=4936040002), [Software Engineer, Robotic Applications](https://www.braincorp.com/company/careers/job/?id=4932451002), [Software QA & Automation Engineer](https://www.braincorp.com/company/careers/job/?id=4937702002), [UX Product Designer](https://www.braincorp.com/company/careers/job/?id=4938077002) Intern positions are available. |
+|[United Wholesale Mortgage](https://careers-uwmcareers.icims.com/jobs/search?ss=1&searchKeyword=2021&searchCategory=&searchZip=&searchRadius=20)| Pontiac, MI | [IT](https://careers-uwmcareers.icims.com/jobs/6612/it-summer-internship---2021/job) Intern position is available. On-site attendance. |
+|QVC| West Chester, PA; Saint Petersburg, FL | **Closed** Software Engineering, Cyber Security, Software QA and other Intern positions are available. |
+|Jabil| Tampa, St. Petersburg, FL | **Closed** |
+|[The Spaceship Company](https://careers-thespaceshipcompany.icims.com/jobs/6008/internship-various-teams---summer-2021/job)| Mojave, CA | Applicant must be a U.S. citizen, lawful permanent resident of the U.S., protected individual as defined by ITAR (22 CFR §120.15) or eligible to obtain the required authorizations from the U.S. Department of State. |
+|[Federal Reserve Bank of Richmond](https://www.richmondfed.org/about_us/careers/job_openings)| Richmond, VA | Selected candidate is subject to special background check procedures. Sponsorship is not available. US Citizenship or US Permanent Resident status is required. |
+|Wabtec| Various | **Closed** Legal authorization to work in the U.S. is required. |
+|[Global Traffic Technologies](https://careers.vontier.com/us/en/search-results?keywords=2021)| Oakdale, MN | [Software Engineering](https://careers.vontier.com/us/en/job/GLO000184/Software-Engineering-Intern-Summer-2021), [Firmware Engineering](https://careers.vontier.com/us/en/job/GLO000187/Firmware-Engineering-Intern-Summer-2021) Intern positions are available. Remote may be possible. |
+|[Cobham Advanced Electronic Solutions](https://careers-caes.icims.com/jobs/search?ics_keywords=2021)| Colorado Springs, CO | |
+|[Bell Flight](https://textron.taleo.net/careersection/bell/jobsearch.ftl?lang=en)| Fort Worth, TX; Johnson City, Piney Flats, TN | [IT](https://textron.taleo.net/careersection/bell/jobdetail.ftl?job=284724) and other Intern positions are available. Non-U.S. persons selected must meet eligibility requirements for access to export-restricted information. |
+|[Riverside Research](https://boards.greenhouse.io/riversideresearch/jobs/4208919003)| Champaign, IL; Lexington, MA | [Software Engineering (Lexington, MA)](https://boards.greenhouse.io/riversideresearch/jobs/4208777003) Intern position is also available. Positions are available during Spring, Summer, and Fall of 2021. Must be able to obtain and maintain a US Government Secret security clearance (Current US citizen, no felony record, no illegal drug use, no serious financial issues). |
+|[L3Harris Technologies](https://careers.l3harris.com/search-jobs/2021/4832/1)| Various | [Systems Engineer](https://careers.l3harris.com/job/camden/systems-engineer-intern-camden-nj-summer-2021/4832/17891636), [Software Engineering](https://careers.l3harris.com/job/melbourne/software-engineering-intern/4832/17694133) and other Intern positions are available. Security clearances may only be granted to U.S. citizens. In addition, applicants who accept a conditional offer of employment may be subject to government security investigation(s) and must meet eligibility requirements for access to classified information. |
+|Expedition Technology| Herndon, VA | **Closed** Machine Learning, Embedded Software/Firmware Development Intern positions are available. US Citizenship is required due to US Government security clearance rules. |
+|[Roku](https://www.roku.com/jobs/listing?search=2021)| Various | [Machine Learning](https://www.roku.com/jobs/position/2421494/?gh_jid=2421494), [QA Engineer](https://www.roku.com/jobs/position/2383300/?gh_jid=2383300), [Software Engineer](https://www.roku.com/jobs/position/2383269/?gh_jid=2383269) and other Intern positions are available. |
+|[Republic Wireless](https://boards.greenhouse.io/republicwireless?_ga=2.145943924.1563528122.1604832023-1915420884.1604832023)| Raleigh, NC | [Software Development](https://boards.greenhouse.io/republicwireless/jobs/2239341), [Software QA Development](https://boards.greenhouse.io/republicwireless/jobs/2385041), [Product Engineering](https://boards.greenhouse.io/republicwireless/jobs/2408002) and other Intern positions are available. |
+|[OnCourse Learning](https://careers.adtalem.com/us/en/search-results?keywords=2021)| Chicago, IL; Brookfield, WI | |
+|BackerKit| San Francisco, CA | **Closed** |
+|[Kimley-Horn](https://recruiting.ultipro.com/KIM1000KHA/JobBoard/459351ad-a40a-4c57-88ec-b8207700a74e/?q=2021&o=relevance&f5=FWXVmFvaCkutkWTU9-RSog)| Phoenix, AZ | [Sofware Engineering](https://recruiting.ultipro.com/KIM1000KHA/JobBoard/459351ad-a40a-4c57-88ec-b8207700a74e/OpportunityDetail?opportunityId=22b32932-bc5a-4bc1-9385-ec3e11e64414) Intern position is available. Applicants must be legally authorized to work for Kimley-Horn in the U.S. without employer sponsorship. We do not typically sponsor H1-B or any other work visa petitions. |
+|[WPS Health Solutions](https://recruiting2.ultipro.com/WIS1003/JobBoard/e6da0c90-f987-63dc-99a9-fb8c9014f57e/?q=2021&o=relevance)| Madison, WI | [Application Developer](https://recruiting2.ultipro.com/WIS1003/JobBoard/e6da0c90-f987-63dc-99a9-fb8c9014f57e/OpportunityDetail?opportunityId=d8d408ff-4350-461a-b2d2-5c93565d64f7), [Software Test](https://recruiting2.ultipro.com/WIS1003/JobBoard/e6da0c90-f987-63dc-99a9-fb8c9014f57e/OpportunityDetail?opportunityId=4c1e485c-7c4e-4f0b-bcbd-e2dbcfb08114), [Test Automation](https://recruiting2.ultipro.com/WIS1003/JobBoard/e6da0c90-f987-63dc-99a9-fb8c9014f57e/OpportunityDetail?opportunityId=b7ddd2f5-ae18-4ef3-8d34-62e74ef458a5) and other Intern positions are available. U.S. citizenship may be required for some positions due to Department of Defense restrictions. |
+|[Southern California Edison (SCE)](https://www.edisoncareers.com/listjobs/all/search/keyword/2021/sce-brand/sce)| Various CA | [IT (Cybersecurity)](https://www.edisoncareers.com/ShowJob/Id/1013139/2021-Summer-Internship-IT-(Cybersecurity)/sce-brand/sce), [IT](https://www.edisoncareers.com/ShowJob/Id/990886/2021-Summer-Internship-IT-Computer-Science,-Computer-Engineering,-Electrical-Engineering-Majors/sce-brand/sce) and many other Intern positions are available. Positions may require applicant to be legally authorized to work directly as employees for any employer in the United States without visa sponsorship. Relocation may not apply for some positions. |
+|Veritas Technologies| Various, Remote | **Closed** |
+|[BAE Systems](https://jobs.baesystems.com/global/en/search-results?keywords=2021)| Various | [Software Engineering](https://jobs.baesystems.com/global/en/job/64235BR/Software-Programmer-Intern), [Technical](https://jobs.baesystems.com/global/en/job/63851BR/Technical-Intern), [Engineering Data Science](https://jobs.baesystems.com/global/en/job/64091BR/Engineering-Data-Science-Advanced-Analytics-Intern-Spring-or-Summer-2021) and other Intern positions are available. U.S Citizen or Green Card may be required for some positions. Security clearance may also be required. |
+|[H&R Block](https://www.hrblock.com/corporate/career-opportunities/)| Kansas City, MO | |
+|[CSC](https://hczw.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001/requisitions?keyword=2021&mode=location)| Wilmington, DE | [Software Developer](https://hczw.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001/job/1100/?keyword=2021&mode=location), [Data Analytics](https://hczw.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001/job/1094/?keyword=2021&mode=location), [Information Security](https://hczw.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001/job/1092/?keyword=2021&mode=location) and other Intern positions are available. |
+|[Trello](https://neuvoo.com/view/?id=c3d561739d98&source=linkedin&utm_source=partner&utm_medium=linkedin&puid=3aedcdcdfaccddcb3deagddf3de98ddd7dd7ca)| San Francisco, CA | Not eligible for Visa sponsorship. Unfortunately, we do not offer U.S. work visa sponsorship to F-1 or J-1 students at this time. |
+|X, the moonshot factory| Mountain View, CA; Remote | **Closed** Software Engineering, Tech For Good Intern, Everyday Robot Project Intern positions are available. Formerly known as Google X. |
+|[O-I](https://careers.peopleclick.com/careerscp/client_endevis/external/en-us/search.do)| Perrysburg, OH | Must be authorized to work in the U.S. on a full-time basis. (O-I does not sponsor working visas for internships or co-ops). |
+|[Square](https://www.smartrecruiters.com/Square/743999724513159)| San Francisco, CA | |
+|[NerdWallet](https://www.nerdwallet.com/careers/job/2306621) | SF | |
+|[Equifax](https://careers.equifax.com/global/en/search-results?keywords=2021)| St. Louis, MO | Various opportunities are available, from Java  to Software Engineering Intern. |
+|[Keysight Technologies](https://jobs.keysight.com/search/?q=Intern&startrow=15)| Various | [Software Development](https://jobs.keysight.com/job/Austin-Intern-Tech-I-TX-73301/680767800/), [Firmware Engineer](https://jobs.keysight.com/job/Santa-Rosa-Firmware-Engineer-Intern-CA-95401/685500800/), [Software System Test](https://jobs.keysight.com/job/Austin-Software-System-Test-Intern-TX-73301/675991100/) and other Intern positions are available. Some positions may involve access to export-controlled information, US Citizenship or Permanent Residency may be Required. |
+|[Canoo](https://canoo.breezy.hr/p/21cf88205677-embedded-software-intern)| Torrance, CA | [Software Operations](https://canoo.breezy.hr/p/3895df44f6cb-software-operations-intern) |
+|[Continental](https://www.continental-jobs.com/index.php?ac=search_result&search_criterion_keyword%5B%5D=Intern&search_criterion_activity_level%5B%5D=3&search_criterion_country%5B%5D=50&search_criterion_language%5B%5D=EN&search_criterion_channel%5B%5D=12&language=2)| Auburn Hills, MI | |
+|[Gotion](http://www.gotion.com/careers/#job-listing)| Fremont, CA | |
+|[Ball Aerospace](https://jobs.ball.com/aerospace/search/?createNewAlert=false&q=2021&locationsearch=)| Albuquerque, NM; Various CO | Only Fall 2021 Internships are available. US citizenship may be required. Relocation may be available. |
+|[American Family Insurance](https://amfam.wd1.myworkdayjobs.com/Careers/0/refreshFacet/318c8bb6f553100021d223d9780d30be)| De Pere, Madison, WI; Overland Park, KS; Florida; Remote | Offer to selected candidate will be made contingent on the results of applicable background checks. |
+|[Caterpillar](https://caterpillarcareers.ttcportals.com/search/jobs/in/country/united-states?q=2021)| Various IL | This employer is not currently hiring foreign national applicants that require or will require sponsorship tied to a specific employer, such as H, L, TN, F, J, E, O. |
+|[Summit Credit Union](https://recruiting.ultipro.com/SUM1007SUMCU/JobBoard/e30746ba-96e7-4dbb-8472-b4993f78eb75/OpportunityDetail?opportunityId=32d1cee2-4925-4292-a744-f8a60d0189e7)| Cottage Grove, WI | |
+|Pearson| Various |**Closed** Developer, Security Engineering, Site Reliability Engineer and other Intern positions are available. Some positions may require interns to be within driving distance of office location. |
+|[Aldridge Electric](https://aldridge.csod.com/ux/ats/careersite/9/home?c=aldridge&sq=2021&country=us)| Libertyville, IL | |
+|[Veritiv](https://careers.veritivcorp.com/us/en/search-results?keywords=2021&from=10&s=1)| Exton, PA; Atlanta, Norcross, GA | |
+|[KeHE Distributors](https://careers.kehe.com/us/en/search-results?keywords=2021)| Naperville, IL | |
+|KLA| Ann Arbor, MI; Milpitas, CA |**Closed** |
+|[Aerojet Rocketdyne](https://jobs4-aerojet-rocketdyne.icims.com/jobs/search?ics_keywords=2021)| Canoga Park, CA; Huntsville, AL | [Software Engineering - Canoga Park, CA](https://jobs4-aerojet-rocketdyne.icims.com/jobs/17166/job), [Software Engineering - Huntsville, AL](https://jobs4-aerojet-rocketdyne.icims.com/jobs/17141/job) Intern positions are available. Requires U.S. Citizenship, U.S. Permanent Residency or other status as a U.S. Person. Must be able to satisfy federal government requirements for access to government information and having dual citizenship may preclude you from being able to meet this requirement. |
+|[H.B. Fuller](https://jobs.hbfuller.com/job/vadnais-heights/it-operations-support-intern/541/2321939616)| Vadnais Heights, MN | |
+|[VMware](https://careers.vmware.com/main/jobs?keywords=2021&page=1&sortBy=relevance&location=United%20States&woe=12&stretchUnit=MILES&stretch=50)| Various | Various positions are available. Job position may not eligible for employment-based immigration that is sponsored by VMware. |
+|[F&G](https://www.fglife.com/about/careers.html)| Des Moines, IA | |
+|[Alaska Airlines](https://alaskaair.jobs/jobs/?q=2021)| Seattle, WA | Various positions are available. Must be authorized to work in the U.S. |
+|[Pacific Scientific Energetic Materials](https://careers.fortive.com/search-results?keywords=2021)| Chandler, AZ; Hollister, CA | |
+|[Anaren](https://www.ttmtech.com/careers/careers_search.aspx?gnk=job&gni=8a78859f7475f51a017492c3ae77757d&lang=en)| Syracuse, NY | |
+|Chatham Financial| Kennett Square, PA; Denver, CO | **Closed** Software Developer, Information Security Analyst and other Intern positions are available. |
+|[Orchard](https://boards.greenhouse.io/perch1/jobs/4867481002)| New York, NY | |
+|Remitly| Seattle, WA | Remitly is an E-Verify Employer. |
+|[Teradyne](https://jobs.teradyne.com/search/?createNewAlert=false&q=2021&optionsFacetsDD_customfield1=&optionsFacetsDD_dept=)| North Reading, MA | |
+|[Citizens Bank](https://jobs.citizensbank.com/search-jobs/2021/288/1?fl=6252001&glat=54.6872&glon=25.2797)| Various | Please note that U.S. Immigration sponsorship or work visa may not be available for some positions, so candidates must have permanent authorization to work in the U.S. |
+|[Sumo Logic](https://boards.greenhouse.io/sumologic/jobs/2440650?t=45c8c7f91) | Redwood City, CA | [Backend](https://boards.greenhouse.io/sumologic/jobs/2454426?t=45c8c7f91), [Backend Advanced Analytics](https://boards.greenhouse.io/sumologic/jobs/2456436) |
+|[Syngenta](https://syngenta.taleo.net/careersection/unitedstates/jobdetail.ftl?job=18021262)| Greensboro, NC | |
+|[Celanese](https://career-celanese.icims.com/jobs/10602/data-analyst-intern--in-information-technology/job?hub=11)| Irving, TX | Must be elegible to work in the U.S. with no restrictions. |
+|[Hilti](https://careers.hilti.com/en/search/jobs/2021?f%5B0%5D=sm_field_country%3AUS&f%5B1%5D=im_field_job_department%3A256)| Plano, TX; Tulsa, OK | Must be eligible to work in the US permanently without sponsorship. Positions may require applicants to be willing to relocate nationally. |
+|First Solar| Perrysburg, OH | **Closed** |
+|[FedEx Services](https://careers.fedex.com/servicescareers/jobs?keywords=2021)| Pittsburgh, PA; Lakeland, FL | Various positions are available. Relocation assistance may not be available. |
+|[Thermo Fisher Scientific](https://jobs.thermofisher.com/global/en/search-results?m=3&keywords=2021)| Various | [Software Scientist](https://jobs.thermofisher.com/global/en/job/136284BR/Summer-2021-Software-Scientist-Internship) Intern position is available.  |
+|[DraftKings](https://careers.draftkings.com/apply?id=a878b814-fffa-40d6-b501-f504c9287180&title=software-engineering-intern---summer-2021)| Boston, MA | |
+|[Cvent](https://www.cvent.com/en/careers/open-positions)| Tysons Corner, VA | |
+|[Reservoir Labs](https://www.reservoir.com/careers/?gh_jid=4894598002)| New York, NY | Currently Reservoir Labs is operating remotely. Should on-site work resume by Summer 2021, this role is intended to be held out of Reservoir Labs' New York office. |
+|[Wing](https://wing.com/careers/)| Remote | [Software Engineer Intern, Android](https://wing.com/careers/4955776002/), [Software Engineer Intern, Computer Vision, Perception](https://wing.com/careers/4953878002/), [Software Engineer Intern, Front End](https://wing.com/careers/4953784002/) and other Intern positions are available. Participation in the internship program requires that you are located in the United States for the duration of the internship program. Individuals applying for this position will not be eligible for immigration sponsorship. |
+|[Beyond Limits](https://www.beyond.ai/careers/open-positions/?job_category=Internships)| Glendale, CA | Must be legally authorized to work in the U.S. Must be able to provide own housing and transportation to/from job site throughout the duration of internship assignment. |
+|[Karat](https://boards.greenhouse.io/karat/jobs/4252508002)| Seattle, WA | |
+|[Roche](https://www.roche.com/careers/jobs/jobsearch.htm?keywords=2021&countryCodes=US)| Santa Clara, Pleasanton CA | Majority of internships are currently planned to be virtual with the option for interns to work remotely from within U.S. Borders. |
+|[Qorvo](https://www.qorvo.com/careers/job-search)| Greensboro, NC | Some positions are part of business units that contract with the US government, so qualified candidates must be U.S. persons (generally a US citizen or green card holder). Individuals holding temporary visas, such as F-1 or H-1B, are not U.S. persons. Some positions may require applicant to be capable of obtaining US Secret Clearance. |
+|Blackbaud| Remote |**Closed** |
+|[NASA Jet Propulsion Laboratory](https://jpl.jobs/job-search?preselected=60,61,62,67,68,70)| Pasadena, CA | Must have ability to obtain work authorization. |
+|[FLIR Systems](https://flir.wd1.myworkdayjobs.com/en-US/flircareers/job/US---Chelmsford-MA/Software-Engineering-Intern_REQ14821-1)| Chelmsford, MA |  |
+|[McAfee](https://careers.mcafee.com/job/plano/cybersecurity-technical-support-engineer-intern/731/17956783)| Plano, TX | Must be able to commute to Plano, TX (when the office is open). Relocation Assistance is not provided. (we may be in the office then). Must be authorized to work without visa (CPT) restrictions. |
+|[Modern Woodmen of America](https://recruiting.ultipro.com/MOD1003MWA/JobBoard/8990acfc-04f3-d65f-0565-a772e1a0157b/OpportunityDetail?opportunityId=60c2431d-d9fe-4557-9b2a-9db622e5dcc1)| Rock Island, IL | |
+|[Pluralsight](https://pluralsight.wd1.myworkdayjobs.com/Careers/0/refreshFacet/318c8bb6f553100021d223d9780d30be)| Draper, UT | |
+|[GrammaTech](https://careers-grammatech.icims.com/jobs/search) | Ithaca, NY | |
+|Inmar Intelligence| Winston Salem, NC |**Closed** |
+|[Western Alliance Bank](https://westernalliancebank.wd5.myworkdayjobs.com/en-US/WAB/job/Phoenix-AZ/Summer-Intern-2021--Phoenix--Data-Analyst-Financial-Crimes_R1458)| Phoenix, AZ | |
+|[Argo AI](https://www.argo.ai/join-us/)| Metro Detroit, MI; Palo Alto, CA; Pittsburgh, PA or potentially Remote | Various positions are available. If COVID-19 prevents us from doing so, internships will be conducted remotely. |
+|[Illumio](https://www.illumio.com/career-openings)| Sunnyvale, CA | [Data Platform Back-End](http://www.illumio.com/career-openings?gh_jid=4968525002), [Front-End](http://www.illumio.com/career-openings?gh_jid=4961070002), [QA](http://www.illumio.com/career-openings?gh_jid=4961040002) and other Intern positions are available. Some positions may require to have authorization to work in the United States. |
+|[Gecko Robotics](https://www.geckorobotics.com/company/careers)| Pittsburgh, PA | |
+|[LabCorp](https://jobs.labcorp.com/search-jobs/2021/668/1)| San Diego, CA; Burlington, Durham, NC; Town of Westborough, MA; Remote | Various positions are available. Remote participation in the internship is also a possibility. |
+|[SeatGeek](https://seatgeek.com/jobs/125938)| NYC | |
+|[MicroStrategy](https://www.smartrecruiters.com/MicroStrategy1/743999724898333-software-engineering-intern-multiple-openings-)| Tysons Corner, VA | Various teams and technologies are available. |
+|[DriveTime](https://jobs.drivetime.com/jobs?page_size=50&page_number=1&keyword=Internship&sort_by=score&sort_order=DESC)| Tempe, AZ | [Application Developer](https://jobs.drivetime.com/application-developer-internship/job/13839205), [Data Science](https://jobs.drivetime.com/data-science-internship/job/13839201), [Database Developer](https://jobs.drivetime.com/database-developer-internship/job/13839204) and other Intern positions are available. Hiring is contingent upon successful completion of our background and drug screening process. |
+|[Rockland Trust](https://rocklandtrust.taleo.net/careersection/ex/jobdetail.ftl?job=200000DN)| Plymouth, MA | |
+|[HCSS](https://careers.hcss.com/data-analyst-intern_2461513/)| Houston, TX | This is NOT a contract position, and at this time we are NOT sponsoring H1-B Visas. You will work remotely during COVID with the need to relocate to Houston post-COVID (relocation assistance may be possible). |
+|Bose Corporation| Boston, MA; Remote |**Closed** |
+|[Interactive Brokers](https://boards.greenhouse.io/ibkr/jobs/4952920002)| Greenwich, CT | |
+|[SPX Corporation](https://career8.successfactors.com/career?company=SPX&career%5fns=job%5flisting%5fsummary&navBarLevel=JOB%5fSEARCH&_s.crb=66tNfIJYJpEr5ysr3Gu5j1a%2fI97NlQ4jO0iIg7ZQBz4%3d)| East Stroudsburg, PA | Must be a US Citizen or have legal US working status. |
+|[Jack Henry & Associates](https://jackhenry.avature.net/careers/SearchJobs/2021?jobRecordsPerPage=6&)| Elizabethtown, Louisville, KY; Remote | [IPay Software Engineer](https://jackhenry.avature.net/careers/JobDetail/iPay-Software-Engineer-Intern-2021/8409), [Network Engineer](https://jackhenry.avature.net/careers/JobDetail/Network-Engineer-Intern-2021/8466) and other Intern positions are available. Applicant must meet legal requirements to work in the U.S. for an indefinite period of time. |
+|[Asurion](https://careers.asurion.com//ListJobs?CloudSearchValue=2021&prefilters=none&CloudSearchLocation=none)| Nashville, TN; Remote | Various positions are available. |
+|Harris Computer| Albany, NY |**Closed**  |
+|[Yale University](https://sjobs.brassring.com/TGnewUI/Search/home/HomeWithPreLoad?partnerid=25053&siteid=5248&PageType=JobDetails&jobid=1445244)| New Haven, CT | All candidates for employment will be subject to pre-employment background screening for this position, which may include motor vehicle, DOT certification, drug testing and credit checks based on the position description and job requirements. |
+|Charles River Development| Burlington, MA | **Closed** |
+|[William Blair](https://williamblair.avature.net/careers/SearchJobs/2021)| Chicago, IL | |
+|[Ericsson](https://jobs.ericsson.com/search/?createNewAlert=false&q=Internship&locationsearch=United+States&optionsFacetsDD_customfield1=)| Plano, TX | Various positions are available.  |
+|[Mathematica](https://careers.mathematica.org/search-jobs/2021/727/1?fl=6252001)| Various; Remote | COVID-19 accommodations: This internship will be offered remotely with the option to work in one of our offices if they are open in summer 2021. |
+|[Quantlab](https://www.quantlab.com/careers)| Houston, TX; Remote | Internships may also be 100% virtual. |
+|[Tapad](https://www.tapad.com/careers/openings?gh_jid=2415752)| NYC | |
+|[Wish](https://www.wish.com/careers/jobs)| SF; Remote | |
+|Equinix| Sunnyvale, Redwood City, CA; Remote | **Closed** |
+|[Banco Santander](https://careers.santander.com/search-jobs/2021%3Futm_source%3Dsantander.com%26utm_medium%3Dreferral%26utm_campaign%3Dcareer)| Dallas, TX; Boston, MA | |
+|[Alteryx](https://alteryx.wd5.myworkdayjobs.com/en-US/AlteryxCareers/job/Boston-Massachusetts/Software-Engineer-Intern--Summer-2021-_R3042-1)| Remote | Must be legally authorized to work in the U.S. and should not require visa sponsorship now or in the future. |
+|[Dexcom](https://careers.dexcom.com/careers?pid=2024253&query=2021&domain=dexcom.com)| San Diego, CA; Portland, OR | |
+|[Voya Financial](https://godirect.wd5.myworkdayjobs.com/en-US/voya_jobs/job/CT---Windsor-One-Orange-Way/Summer-2021-Information-Technology-Summer-Intern_JR0022813?_ga=2.3231408.1603606280.1606849401-1231342794.1606849401)| Windsor, CT | |
+|[Lockton Companies](https://lockton.referrals.selectminds.com/jobs/information-technology-intern-2564)| Kansas City, MO | Applicant must be able to legally work in the United States. |
+|[Peterbilt Motors Company](https://jobs.paccar.com/search/?q=2021&q2=&alertId=&locationsearch=&title=&location=US&department=&date=&facility=)| Denton, TX | Various positions are available. |
+|[Box](https://careers.box.com/us/en/job/2519095/Software-Engineering-Intern-Summer-2021)| Redwood City, CA | The internship is 12-weeks long and will begin on a remote basis, with the possibility of working in our Redwood City, CA headquarters depending on circumstances with COVID-19 next summer 2021. |
+|[Apptio](https://www.apptio.com/company/careers/job-openings?gh_jid=2454266)| Bellevue, WA | Local to WA state candidate preferred. |
+|[URBN](https://career4.successfactors.com/career?career%5fns=job%5flisting&company=URBN&navBarLevel=JOB%5fSEARCH&rcm%5fsite%5flocale=en%5fUS&site=VjItakNiUTR0TXNKeEgvN2plaVNWZkx6QT09&career_job_req_id=115126&selected_lang=en_US&jobAlertController_jobAlertId=&jobAlertController_jobAlertName=&_s.crb=lmC7XuAqVAPNJvSCq%2b9LIFc3C%2fMpuZRaC65TboJSg94%3d)| Philadelphia, PA | |
+|[PTC](https://careers.ptc.com/TGnewUI/Search/Home/Home?partnerid=2&siteid=5213#keyWordSearch=2021&locationSearch=)| Boston, MA | |
+|[American Century Investments](https://americancentury.wd5.myworkdayjobs.com/AmericanCenturyInvestments/0/refreshFacet/318c8bb6f553100021d223d9780d30be)| Kansas City, MO; NYC | |
+|[HARMAN](https://jobs.harman.com/search-jobs/2021/United%20States?orgIds=23226&kt=1&alp=6252001&alt=2)| Novi, MI | Highly prefer candidates who live within a commutable distance. Successfully complete a background investigation and drug screen as a condition of employment. |
+|[Academy Sports + Outdoors](https://academy.wd1.myworkdayjobs.com/en-US/Careers/job/Headquarters---Katy-TX/XMLNAME-2021-Summer-Internship_R192716)| Katy, TX | Candidates must be open to relocation (Internship will take place at Katy, TX HC). Candidates must also be open to full time employment upon internship completion. |
+|[Mouser Electronics](https://phf.tbe.taleo.net/phf03/ats/careers/v2/viewRequisition?org=MOUSER&cws=40&rid=10398)| Mansfield, TX | |
+|[Enthought](https://jobs.lever.co/enthought/cf87b6ce-77a6-465d-afeb-1280343d417a)| Austin, TX | |
+|[BMO Harris Bank](https://jobs.bmoharris.com/us/en/search-results?keywords=2021)| Chicago, IL | |
+|[UCAR](https://ucar.wd5.myworkdayjobs.com/en-US/UCAR_Careers/job/Foothills-Lab-4/XMLNAME-2021-Unidata-Summer-Internship_REQ-2020-258-1)| Boulder, CO | UCAR/NCAR will not sponsor a work visa to fill this position. A pre-employment screening is conducted in conjunction with an offer for employment. |
+|[Danfoss](https://jobs.danfoss.com/job/Loves-Park-Embedded-Software-Engineering-Intern-IL-61111/520963902/)| Loves Park, IL | |
+|[Williams-Sonoma](https://ehac.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1/requisitions?keyword=2021)| San Jose, San Francisco, CA | |
+|[Standard Industries](https://gafsgi.wd5.myworkdayjobs.com/Standard_Careers/0/refreshFacet/318c8bb6f553100021d223d9780d30be)| NY | Must be eligible to work in the U.S. without need for employer-sponsored visa (work permit). |
+|[Arthrex](https://careers.arthrex.com/job/Naples-IT-Intern-FL-34108/697061300/)| Naples, FL | |
+|[Marshfield Clinic Health System](https://marshfieldclinichealthsystems.wd5.myworkdayjobs.com/en-US/External/job/Marshfield-WI/IT-Intern---Security-Health-Plan-IS-Development_R-0009444)| Marshfield, WI | |
+|[BCG Digital Ventures](https://boards.greenhouse.io/bcgdv/jobs/4964861002?gh_jid=4964861002)| NY | |
+|[Echo Global Logistics](https://echo.wd1.myworkdayjobs.com/en-US/Echo_Logistics/job/Chicago-IL/Software-Engineering-Intern---Chicago_R221)| Chicago, IL | |
+|[Janus Henderson Investors](https://career8.successfactors.com/career?career%5fns=job%5flisting&company=Janus&navBarLevel=JOB%5fSEARCH&rcm%5fsite%5flocale=en%5fUS&career_job_req_id=20811&selected_lang=en_US&jobAlertController_jobAlertId=&jobAlertController_jobAlertName=&_s.crb=xTV4Or09uhlTS43fufyIQXO2FFzas4HbmWHpxUOdROY%3d)| Denver, CO | |
+|[Entegris](https://globalcareers-entegrisinc.icims.com/jobs/search?ss=1&searchKeyword=2021)| Various | |
+|[F5](https://f5.recsolu.com/jobs/DMiS39kMrH1Hb3_AY4JvNg)| Seattle, WA | |
+|[Netflix](https://jobs.netflix.com/search?q=2021)| Los Gatos, CA; Remote | [Data Engineering](https://jobs.netflix.com/jobs/40242907), [Analytics Engineering](https://jobs.netflix.com/jobs/40242270) Intern positions are available. |
+|[Visa](https://usa.visa.com/careers.html)| Various | |
+|[SPA](https://careers-spa.icims.com/jobs/search?ics_keywords=2021)| Alexandria, VA | The candidate must be a US Citizen with the ability to obtain a DoD Secret clearance. |
+|[Proofpoint](https://proofpoint.wd5.myworkdayjobs.com/en-US/ProofpointCareers/job/Draper-UT/Software-Engineer-Part-Time-Intern---Undergrad_R4508)| Draper, UT ; Durham, NC | [Data Science Here](https://proofpoint.wd5.myworkdayjobs.com/en-US/ProofpointCareers/job/Durham-North-Carolina/Data-Science-Summer-Intern---Undergraduate_R4668) |
+|[Ogilvy](https://uscareers-ogilvy.icims.com/jobs/7994/2021-summer-internship-program/job?hub=15)| Various | |
+|[Publicis Sapient](https://jobs.smartrecruiters.com/PublicisGroupe/743999726273814-engineering-summer-internship-class-of-2022?trid=fabf8f5c-18fc-43ce-ba06-84dac34b9203)| Various | |
+|[John Deere](https://jobs.deere.com/search/?q=&q2=&alertId=&title=2021&department=&location=US&date=)| Moline, IL; Various | [Data Science & Analytics](https://jobs.deere.com/job/Moline-Data-Science-&-Analytics-Summer-Intern-2021a-IL-61265/673424600/), [Software Enginerring & IT Security](https://jobs.deere.com/job/Moline-IT-Software-Engineering-&-Cyber-Security-Summer-Intern-2021a-IL-61265/673262400/) Intern positions are available. We have internship locations across the United States so you must be willing to relocate and travel domestically. Work Statement: US Visa sponsorship is not available for this position. |
+|[Impira](https://impira.com/careers?gh_jid=4269035002)| San Francisco, CA | |
+|[Bill.com](https://jobs.lever.co/bill)| Remote, USA | [Machine Learning](https://jobs.lever.co/bill/c9603d02-9526-4d36-be1a-9792deec29e5), [Software Engineering](https://jobs.lever.co/bill/18473b24-ab2e-4b69-8814-3d5b2ca6d415) Intern positions are available. |
+|[Revantage](https://www.revantage.com/americas/careers/#careers)| Chicago, IL | |
+|[Tapestry](https://careers.tapestry.com/job/New-York-Summer-IT-&-Data-Science-Internships-NY/694868700/)| NYC | |
+|[Ciena](https://careers.ciena.com/us/en/search-results?m=3&keywords=Intern)| Various | [Software Development](https://careers.ciena.com/us/en/job/R014303/Summer-Intern-Software-Development), [Cloud Engineering](https://careers.ciena.com/us/en/job/R014326/Friends-and-Family-Cloud-Engineering-Inter) Intern positions are available. |
+|[Boehringer Ingelheim](https://tas-boehringer.taleo.net/careersection/global+template+career+section+28external29/jobsearch.ftl?lang=en#)| Ridgefield, CT | [IT RDM Chromatography Systems](https://tas-boehringer.taleo.net/careersection/global+template+career+section+28external29/jobdetail.ftl?job=2011001), [Data Systems](https://tas-boehringer.taleo.net/careersection/global+template+career+section+28external29/jobdetail.ftl?job=2010827&tz=GMT%2B02%3A00), [IT Business Analyst & Web Developer](https://tas-boehringer.taleo.net/careersection/global+template+career+section+28external29/jobdetail.ftl?job=2012230&tz=GMT%2B02%3A00) and other Intern positions are available. Must be legally authorized to work in the United States without restriction. Must be willing to take a drug test and post-offer physical (if required). |
+|[Frontier Technology](https://www.influxdata.com/careers/)| Colorado Springs, CO; Beverly, MA | [Software Developer/Systems Engineer](https://careers-fti-net.icims.com/jobs/3221/job), [Software Developer/Engineer](https://careers-fti-net.icims.com/jobs/3188/job) Intern positions are available. Must be a U.S. Citizen and be able to obtain and maintain a government security clearance. |
+|[CommScope](https://jobs.commscope.com/search/?q=&q2=&alertId=&title=Intern&location=&department=&date=)| Various | [Software Engineering](https://jobs.commscope.com/job/Richardson-Intern%2C-Software-Engineering-Texa/691941600/), [Data Analyst](https://jobs.commscope.com/job/Horsham-Intern%2C-Data-Analyst-Penn/697357500/), [IT Operations](https://jobs.commscope.com/job/Suwanee-IT-Operations-Intern-Geor/691180200/) and other Intern positions are available. |
+|Pega| Various | Front-end Developer, Software Engineer and other Intern positions are available. |
+|[BRE Hotels & Resorts](https://careers-brehotels.icims.com/jobs/2086/job)| NYC | Ability to work in New York City in a full-time capacity for 10 weeks. |
+|[Juniper Networks](https://careers.juniper.net/careers/careers/#/jobdescription?jid=946276)| Westford, MA | In compliance with federal law, all persons hired will be required to verify identity and eligibility to work in the United States and to complete the required employment eligibility verification form upon hire. |
+|[Brother](https://careers.brother-usa.com/job/BROTUSP-100017en_US/Summer-2021-Internship-Program)| Various | |
+|[Rubrik](https://www.rubrik.com/en/company/careers/departments/job.2458231.56313)| Palo Alto, CA | |
+|[Air Products](https://sjobs.brassring.com/TGnewUI/Search/home/HomeWithPreLoad?partnerid=25091&siteid=5105&PageType=JobDetails&jobid=702696)|  Allentown, PA | |
+|[edX](https://boards.greenhouse.io/edx/jobs/2449873)| Cambridge, MA; Remote | |
+|One Medical| San Francisco, CA | |
+|[a.i. solutions](https://recruiting.ultipro.com/AIS1000AISI/JobBoard/b22b728d-47a6-4550-9005-01c83b9a527f/OpportunityDetail?opportunityId=d6a3ca93-3152-4e78-b63a-45c217f0aa8e)| Lanham, Telework, MD | U.S. citizenship is required. |
+|[RingCentral](https://www.ringcentral.com/whyringcentral/job-description.html?c=3097f0332cf201e572dbfafccc00da62&location=Belmont,%20California,%20USA&department=Internships%20%26%20University%20Recruiting#toContent)| Belmont, CA | |
+|[Arthur AI](https://boards.greenhouse.io/arthurai/jobs/4278024003?t=bea0d56c3us)| NYC | |
+|[Uline](https://www.uline.jobs/JobDetails?culture=en&jobid=3887BR&jobtitle=Software-Developer-Internship---Paid)| Pleasant Prairie, WI | All new hires must complete a pre-employment drug screen. |
+|Homesite Insurance| Boston, MA; Seattle, WA |**Closed** Software Engineer, Data Scientist, Database/Python Developer and other Intern positions are available. |
+|[MITRE](https://mitre.wd5.myworkdayjobs.com/MITRE/1/refreshFacet/318c8bb6f553100021d223d9780d30be)| Various | Various positions are available. 70% of MITRE's full-time jobs require US government security clearances, therefore many internships require that the candidates be clearable. |
+|Castleton Commodities| Stamford, CT | **Closed** |
+|[Siemens Healthineers](https://jobs.siemens.com/healthineers/jobs?page=1&keywords=2021&sortBy=relevance&location=United%20States&woe=12&stretchUnit=MILES&stretch=0)| Knoxville, TN; Walpole, MA | No housing stipend or relocation will be offered for some positions. |
+|[Caissa](https://caissallc.com/careers/#!)| NYC | |
+|[WePay](https://go.wepay.com/posting/?jobId=97bfaef8-56ab-419d-afb9-007256b5f38c)| Redwood City, CA | |
+|[Datavant](https://boards.greenhouse.io/datavant/jobs/4117677002)| San Francisco, CA | |
+|[Calspan](https://careers-calspan.icims.com/jobs/1456/software-engineering-intern---2021-internship/job?in_iframe=1)| Buffalo, NY | [Security Analyst](https://careers-calspan.icims.com/jobs/1449/security-analyst-intern---2021-internship-program/job) Intern position. Due to security requirements, some positions require candidates to have US Citizenship. Please note that there is no relocation or housing assistance provided. |
+|[Vecna Robotics](https://www.vecnarobotics.com/careers/)| Waltham, MA | |
+|[NT Concepts](https://careers-ntconcepts.icims.com/jobs/1783/software-developer-summer-2021-intern/job?mode=job&iis=Job+Posting&iisn=LinkedIn&mobile=false&width=1663&height=500&bga=true&needsRedirect=false&jan1offset=120&jun1offset=180)| Vienna, VA | U.S. Citizen with the ability to achieve a clearance. |
+|[Dev Technology Group](https://devtechnology.com/careers/)| Reston, VA; Washington, D.C; Remote | |
+|[Trustmark](https://www.trustmarkbenefits.com/careers)| Lake Forest, IL | Various positions are available. |
+|[Opendoor](https://jobs.lever.co/opendoor/13723d39-e96d-48aa-b414-eaa24e9f5b74/apply?lever-origin=applied&lever-source%5B%5D=BuiltInSan%20Francisco)| SF, ATL, LA or Remote | |
+|[FiscalNote](https://jobs.lever.co/fiscalnote/d7bec0af-d2df-4621-a568-8f3e0d6f71fb/apply)| Washington, DC | New team members, along with our current staff, will temporarily work remotely (unless communicated otherwise). |
+|[Astronautics](https://kearfott-openhire.silkroad.com/epostings/index.cfm?fuseaction=app.jobsearch)| Phoenix, AZ; Oak Creek, Milwaukee, WI; | [Software Engineering](https://kearfott-openhire.silkroad.com/epostings/index.cfm?fuseaction=app.jobinfo&jobid=1517&source=ONLINE&JobOwner=992419&company_id=16988&version=2&byBusinessUnit=NULL&bycountry=0&bystate=0&byRegion=&bylocation=NULL&keywords=Intern&byCat=&proximityCountry=&postalCode=&radiusDistance=&isKilometers=&tosearch=yes&city=), [Programmable Logic Device (PLD)](https://kearfott-openhire.silkroad.com/epostings/index.cfm?fuseaction=app.jobinfo&jobid=1511&source=ONLINE&JobOwner=992419&company_id=16988&version=2&byBusinessUnit=NULL&bycountry=0&bystate=0&byRegion=&bylocation=NULL&keywords=Intern&byCat=&proximityCountry=&postalCode=&radiusDistance=&isKilometers=&tosearch=yes&city=) and other Intern positions are available. Must be permanently eligible to work in the United States without sponsorship. |
+|Huntsman|  Houston, TX | **Closed** Must be authorized to work in U.S. |
+|[AppLovin](https://www.applovin.com/jobs/)| Palo Alto, CA | [Backend](https://jobs.lever.co/applovin/e3513df1-b968-433a-b21f-6602664b6a0d), [DevOps](https://jobs.lever.co/applovin/4b73d9ee-95c2-4471-83ef-18f7cfdb0bfd), [Mobile Software Engineering](https://jobs.lever.co/applovin/f0487da0-c418-4c64-b57d-003d93906dfa) and other Intern positions are available. |
+|[Zenly](https://www.zigo.com/JF/Startup-Software-Developer-Internship-jobs-in-New-York-New-York-2051496135?sid=asplink)| NYC | This is an unpaid internship. |
+|Designer Brands| Various | **Closed** Various positions are available. |
+|[Ro](https://jobs.lever.co/ro/92598b00-3ccc-43b8-aff2-21b7add3d0ce)| NYC; Remote | Various positions are available. |
+|[Inspire Brands](https://careers.inspirebrands.com/us/en/search-results?keywords=2021&s=1)| Atlanta, GA; Oklahoma City, OK | [IT Data Engineering](https://careers.inspirebrands.com/us/en/job/JR7191/Summer-2021-Intern-IT-Data-Engineering), [Data Science](https://careers.inspirebrands.com/us/en/job/JR7188/Summer-2021-Intern-Data-Science), [Media Analytics](https://careers.inspirebrands.com/us/en/job/JR7230/Summer-2021-Intern-Media-Analytics) and other Intern positions are available. |
+|[WP Engine](https://wpengine.eightfold.ai/careers?pid=2206635&query=2021&domain=wpengine.com)| Austin, TX; Omaha, NE | |
+|[Edgenuity](https://www.talent.com/view?id=de792aad7c7a&source=linkedin&utm_medium=linkedin)| Scottsdale, AZ | |
+|Schnuck Markets| St. Louis, Mo | **Closed**|
+|[Colony Brands](https://sjobs.brassring.com/TGnewUI/Search/Home/Home?partnerid=26513&siteid=5661#keyWordSearch=2021&locationSearch=)| IA; WI; MO | [Cloud Engineering](https://sjobs.brassring.com/TGnewUI/Search/home/HomeWithPreLoad?partnerid=26513&siteid=5661&PageType=JobDetails&jobid=644341), [Data Analyst](https://sjobs.brassring.com/TGnewUI/Search/home/HomeWithPreLoad?partnerid=26513&siteid=5661&PageType=JobDetails&jobid=643956#jobDetails=643956_5661), [Web Developer](https://sjobs.brassring.com/TGnewUI/Search/home/HomeWithPreLoad?partnerid=26513&siteid=5661&PageType=JobDetails&jobid=643964#jobDetails=643964_5661) and other Intern positions are available. |
+|[Torch Technologies](https://torchtechnologies.hua.hrsmart.com/hr/ats/Posting/view/2708)| Huntsville, AL | |
+|[Wells Enterprises](https://wells.taleo.net/careersection/2/jobdetail.ftl?job=2000001190)| Le Mars, IA | |
+|[Pendo.io](https://www.pendo.io/careers/)| Raleigh, NC | [Data Analytics](https://boards.greenhouse.io/pendo/jobs/4997538002), [Security Engineering](https://boards.greenhouse.io/pendo/jobs/5002558002), [Software Engineer](https://boards.greenhouse.io/pendo/jobs/4998501002) Intern positions are available. |
+|[Second Spectrum](https://jobs.lever.co/secondspectrum/47e1b768-0f6b-4760-8c40-c5f69062c867/apply)| Los Angeles, CA | This internship is currently scheduled to be remote. This may be changed to an onsite internship in the future pending COVID updates. |
+|[WarnerMedia](https://www.warnermediacareers.com/job/seattle/virtual-hbomax-software-engineering-intern-summer-2021/1174/18301065)| Remote | Relocation is not provided. |
+|[CQL](https://www.cqlcorp.com/careers/software-developer-internship/)| Ann Arbor, Grand Rapids MI | |
+|[FutureSense](https://neuvoo.com/view/?id=d9fa47d3d341&oapply=org_v2020-12&source=joveo_bulk2&utm_source=partner&utm_medium=joveo_bulk2&puid=gadc3de7gada3aeffddc3de93aec3dedbaacdd9d4dacfdafaea33def3debfed3gbdb8bddacdcaed3fddf8ddagd)| Chicago, IL | |
+|[HomeAdvisor](https://boards.greenhouse.io/homeadvisorangieslist)| Denver, CO; Remote | [Applied Data Science](https://boards.greenhouse.io/homeadvisorangieslist/jobs/4892448002), [Data Engineering](https://boards.greenhouse.io/homeadvisorangieslist/jobs/4892442002), [Software Engineering](https://boards.greenhouse.io/homeadvisorangieslist/jobs/4874765002) and other Intern positions are available. Legal authorization to work in the U.S. is required on the first day of employment including F-1 students using OPT, CPT, TN, or STEM for some positions. |
+|[Telligen](https://telligen.com/current-openings/)| West Des Moines, IA | [PC Support Technician](https://recruitingbypaycor.com/career/JobIntroduction.action?clientId=8a7883c65f99acc5015fa313a6da0bed&id=8a78839f7553557d01756b5d4bfa05d5&source=&lang=en), [Software Development](https://recruitingbypaycor.com/career/JobIntroduction.action?clientId=8a7883c65f99acc5015fa313a6da0bed&id=8a78839f7553557d01756b656b7208d6&source=&lang=en) and other Intern positions. Telligen will not provide sponsorship for some positions. If you will require sponsorship for work authorization now or in the future, we cannot consider your application at this time. |
+|[Henkel](https://www.henkel.com/careers/jobs-and-application#selectFilterByParameter=select_34828_0_Career_Level_18682_Career%20Level=Students&select_34828_5_Functional_Area_18674_Functional%20Area=Engineering%3BIT&)| Various | [Data Science](https://www.henkel.com/careers/jobs-and-application/1139612-1139612) and other Intern positions are available. |
+|[Evidation Health](https://evidation.com/careers)| Santa Barbara, Santa Barbara, CA; US Remote | |
+|[Covance](https://careers.covance.com/global/en/search-results?s=1)| Various | [Data Science](https://careers.covance.com/global/en/job/51232/Data-Science-Intern), [IT Quality Assurance](https://careers.covance.com/global/en/job/52401/IT-Quality-Assurance-Intern) and other Intern positions are available. |
+|Dominion Energy| Richmond, VA | **Closed** Certain positions at Dominion Energy may involve access to information and technology subject to export controls under U.S. law, this may result in Dominion Energy limiting its consideration of certain applicants. |
+|[JLL](https://jll.wd1.myworkdayjobs.com/en-US/jllcareers/job/Richmond-VA/XMLNAME-2021-Summer-Intern--Technology--VA_REQ126996?utm_source=jll&utm_medium=referral&utm_campaign=us_careers&utm_content=explore_opportunities)| Richmond, VA | We do not offer relocation assistance or housing for our internship program. |
+|[SelectQuote Benefits](https://www.selectquotecareer.com/?#positions)| Overland Park, KS | [App Dev](https://www.selectquotecareer.com/p/fde45042fd64-information-technology-internship-app-dev), [Business intelligence, ETL, Data Science](https://www.selectquotecareer.com/p/465a91e48fb8-information-technology-internship-business-intelligence-etl-and-data-science), [DevOps and Infrastructure](https://www.selectquotecareer.com/p/5178d0b1ac01-information-technology-internship-devops-and-infrastructure) and other Intern positions are available. |
+|[Arrow Electronics](https://careers.arrow.com/us/en/job/R181822/IT-Intern)| Remote | |
+|[FCA Fiat Chrysler Automobiles](https://careers.fcagroup.com/job/11390451/2021-information-technology-intern-digital-technology-leader-auburn-hills-mi/)| Auburn Hills, MI | |
+|[The TCW Group](https://careers-tcw.icims.com/jobs/1524/job)| Los Angeles, CA | |
+|[PwC](https://jobs.us.pwc.com/search-jobs/2021/932/1?fl=6252001,4566966)| Various | [Innovation Engineer](https://jobs.us.pwc.com/job/denver/innovation-engineer-intern-summer-2021/932/18301165), [Automation CoE Intern](https://jobs.us.pwc.com/job/new-york/automation-coe-intern-summer-2021/932/18301168), [Innovation Technology Development](https://jobs.us.pwc.com/job/dallas/innovation-technology-development-intern-summer-2021/932/18301212) Intern positions are available. |
+|[Interstate Batteries](https://interstate.wd1.myworkdayjobs.com/InterstateBatteries-Careers/1/refreshFacet/318c8bb6f553100021d223d9780d30be)| Dallas, TX | [Software Developer](https://interstate.wd1.myworkdayjobs.com/en-US/InterstateBatteries-Careers/job/US-TX-Dallas/Software-Development-Intern_REQ-3446), [IT Support Analyst](https://interstate.wd1.myworkdayjobs.com/en-US/InterstateBatteries-Careers/job/US-TX-Dallas/IT-Support-Analyst-Intern_REQ-3466) Intern positions are available. Must have lodging in the DFW area. |
+|[Kroll Bond Rating Agency](https://boards.greenhouse.io/krollbondratingagency/jobs/4827176002)| Manhattan, NYC; Remote | |
+|[Barkback](http://smrtr.co/1w44Mj0)| Santa Barbara, CA | You must be able to work from our amazing office located in downtown Santa Barbara. |
+|[Lids](https://careers.lids.com/job/Indianapolis-Summer-2021-Internship-Program-Information-Technology-IN-46278/700647400/)| Indianapolis, IN | |
+|[Adtalem Global Education](https://careers.adtalem.com/us/en/job/116404/Summer-Intern-Analytics-2021)| Chicago, IL | |
+|[Nylas](https://jobs.lever.co/nylas)| San Francisco, CA; Denver, CO; Remote | [Software Engineering](https://jobs.lever.co/nylas/22063c6a-72e0-44d1-879e-096ea42b71d1), [Marketing Operations and Analytics](https://jobs.lever.co/nylas/36dbc87f-937f-41dc-ab36-c371d6e8acee) Intern positions are available. If you are not located in or able to work from a state where Nylas is registered, you will not be eligible for employment. Visa sponsorship may not be available in certain remote locations. |
+|[Hawaiian Electric](https://career4.successfactors.com/career?career%5fns=job%5flisting&company=hawaiianel&navBarLevel=JOB%5fSEARCH&rcm%5fsite%5flocale=en%5fUS&career_job_req_id=4722&selected_lang=en_US&jobAlertController_jobAlertId=&jobAlertController_jobAlertName=&_s.crb=sifOzarhgSAtGu%2fySJRk5j66oVG7h1YuCw2nMRWXvGE%3d)| Oahu, Hawaii | |
+|[Quantum Signal AI](https://quantumsignalai.com/internships/)| Saline, MI | [Software Engineering](https://quantumsignalai.applytojob.com/apply/JRY4xRbxzy/Software-Engineering-Intern), [Simulation Developer](https://quantumsignalai.applytojob.com/apply/AVXRdt9G2g/Simulation-Developer-Intern), [Research Engineer](https://quantumsignalai.applytojob.com/apply/fpULkCrat1/Research-Engineer-Intern) and other Intern positions are available. |
+|[Great American Insurance Group](https://jobs-gaic.icims.com/jobs/search?ss=1&searchKeyword=Intern)| Cincinnati, Richfield, OH | [Data Analyst](https://jobs-gaic.icims.com/jobs/27078/data-analytics-intern---summer-2021/job?in_iframe=1), [Data Developer](https://jobs-gaic.icims.com/jobs/27134/data-developer-intern---summer/job?in_iframe=1) and other Intern positions are available.  |
+|[Shield AI](https://jobs.lever.co/shieldai)| San Diego, CA | [AI](https://jobs.lever.co/shieldai/782a003f-2e96-41fa-a5a5-b99620ea98e4), [Full Stack](https://jobs.lever.co/shieldai/2da3ba0f-6177-47ef-8fca-6490954adf42) Intern positions are available. To conform to U.S. Government regulations, applicant must be a U.S. citizen, lawful permanent resident of the U.S., protected individual as defined by 8 U.S.C. 1324b(a)(3), or eligible to obtain the required authorizations from the U.S. Department of State. |
+|[KSM Consulting](https://jobs.smartrecruiters.com/KSMConsulting/743999721588428-summer-2021-internship)| Indianapolis, IN | |
+|[LogicGate](https://www.logicgate.com/about-us/join-the-team/#positions)| Chicago, IL | |
+|[Centauri](https://phg.tbe.taleo.net/phg01/ats/careers/v2/searchResults?org=INTEGRITYAPPLICATIONS&cws=37)| Ann Arbor, MI; Fairborn, Beavercreek OH | [Technical Intern](https://phg.tbe.taleo.net/phg01/ats/careers/v2/viewRequisition?org=INTEGRITYAPPLICATIONS&cws=37&rid=5015), [Summer Intern](https://phg.tbe.taleo.net/phg01/ats/careers/v2/viewRequisition?org=INTEGRITYAPPLICATIONS&cws=37&rid=4906). Must be a US citizen. May be required to obtain a security clearance based upon project. |
+|[Noblis](https://careers.noblis.org/listings)| Various | [Technical Summer Intern](https://jobs-noblis.icims.com/jobs/8726/2021-technical%2c-summer-intern/job) and other Intern positions are available. U.S. citizenship or U.S. permanent residency status is required. |
+|[NFL](https://nfl.taleo.net/careersection/nfl_ex/jobsearch.ftl)| NYC | Football Data & Analytics, Network Engineer, Software Automation and other Intern positions are available. Some positions require applicants to be legally permitted to work in the United States and international students must have all visas and employment authorizations before the start of the internship. |
+|[Unqork](https://boards.greenhouse.io/internatunqork?t=d892b6fa2)| Remote | [Analytics](https://boards.greenhouse.io/internatunqork/jobs/4646243002?t=d892b6fa2), [Engineering (Components)](https://boards.greenhouse.io/internatunqork/jobs/4993155002?t=d892b6fa2), [Engineering (Data)](https://boards.greenhouse.io/internatunqork/jobs/4645662002?t=d892b6fa2) and other Intern positions are available. |
+|[Amobee](https://www.amobee.com/company/careers/listing/department/)| Various | [Software Engineering / Data Science](https://www.amobee.com/company/careers/internship-summer-2021-software-engineering-data-science-2/) and other Intern positions are available. |
+|[Norfolk Southern Corporation](https://jobs.nscorp.com/search/?createNewAlert=false&q=2021&locationsearch=&optionsFacetsDD_dept=&optionsFacetsDD_customfield1=&optionsFacetsDD_customfield2=&optionsFacetsDD_customfield3=)| Atlanta, GA | [Data Science & Analytics](https://jobs.nscorp.com/job/Atlanta-Summer-2021-Data-Science-and-Analytics-Intern-%28Legal-Operations%29-GA-30309/699742000/) and other Intern positions are available. |
+|[KPISOFT](https://careers.kpisoft.com/#!/joblist)| Houston, TX | [Full-Stack Developer](https://careers.kpisoft.com/#!/job-view/full-stack-developer-intern-houston-tx-usa-reactjs-javascript-html-css-ruby-on-rails-python-mysql-net-c-angularjs-2020082423302096), [Full Stack Data Scientist](https://careers.kpisoft.com/#!/job-view/full-stack-developer-intern-fall-2020-spring-2021-houston-tx-usa-data-science-statistics-innovative-problem-solver-communication-skills-presentation-skills-202005060116359) Intern positions are available. KPISOFT will not be providing visa sponsorship for these positions now or in the future. Therefore, in order to be considered for this KPISOFT position, you must have the ability to work without a need for current or future visa sponsorship. |
+|[Gilmore](https://www.gilmoresolutions.com/company/careers)| Sterling, Wichita, Garden City, KS |  |
+|[Raven Industries](https://jobs.ravenind.com/job/Sioux-Falls-Intern-Software-Engineer-SD-57104-5931/676693800/)| Sioux Falls, SD | |
+|[TeleTracking](https://www.teletracking.com/about/careers)| Pittsburgh, PA | [Technical Support Engineer](https://www.teletracking.com/about/careers/opening?__jvst=Career%20Site&p=job%2FomkgefwU), [Machine Learning Engineer](https://www.teletracking.com/about/careers/opening?__jvst=Career%20Site&p=job%2FopigefwV), [Software Engineer](https://www.teletracking.com/about/careers/opening?__jvst=Career%20Site&p=job%2FomCgefwc) Intern positions are available. |
+|[Syncroness](https://jobs.jobvite.com/syncroness/job/oKVhefwU)| Westminster, CO | |
+|[Federal Reserve Bank of Philadelphia](https://www.philadelphiafed.org/careers/search-for-jobs)| Philadelphia, PA | Various positions are available. Applicants must be able to provide work authorization to prove their eligibility to work in the United States. |
+|[Arcadis](https://careers.arcadis.com/job/ANA011OH/Technology-Intern-Nationwide)| Various; Remote | US citizenship is preferred but not required. |
+|[Financial Times](https://ft.wd3.myworkdayjobs.com/FT_External_Careers/6/refreshFacet/318c8bb6f553100021d223d9780d30be)| NYC | [QA Engineer](https://ft.wd3.myworkdayjobs.com/en-US/FT_External_Careers/job/New-York-35-hours/XMLNAME-2021-QA-Engineer-Summer-Intern_JR005879), [Technology Project Management](https://ft.wd3.myworkdayjobs.com/en-US/FT_External_Careers/job/New-York-35-hours/XMLNAME-2021-Technology-Project-Management-Summer-Intern_JR005881), [Tech Development](https://ft.wd3.myworkdayjobs.com/en-US/FT_External_Careers/job/New-York-35-hours/XMLNAME-2021-Tech-Development-Summer-Intern_JR005878) and other Intern positions are available. |
+|[Everest Reinsurance](https://wd5.myworkdaysite.com/recruiting/everestre/careers/0/refreshFacet/318c8bb6f553100021d223d9780d30be)| Liberty Corner, NJ | [Software Developer](https://wd5.myworkdaysite.com/en-US/recruiting/everestre/careers/job/Liberty-Corner-NJ/XMLNAME-2021-Summer-Internship---Software-Developer---Reinsurance--Technology-Services-_R363), [Cybersecurity](https://wd5.myworkdaysite.com/en-US/recruiting/everestre/careers/job/Liberty-Corner-NJ/XMLNAME-2021-Summer-Internship---Cybersecurity---Technology-Services-_R364), [Azure Data Analytics](https://wd5.myworkdaysite.com/en-US/recruiting/everestre/careers/job/Liberty-Corner-NJ/XMLNAME-2021-Summer-Internship---Azure-Data-Analytics-Developer_R360) and other Intern positions are available. |
+|[Genentech](https://www.gene.com/careers/find-a-job?searchterms=2021&function=&type=&municipality=)| San Francisco, Oceanside, CA; Remote | Various positions are available. Some internship positions are currently planned to be virtual with the option for interns to work remotely from within U.S. Borders. |
+|[Tractor Supply Company](https://tractorsupply.jobs/)| Brentwood, TN | [AI](https://tractorsupply.jobs/jobs/search#/detail/56152447), [Integration](https://tractorsupply.jobs/jobs/search#/detail/58673906) and other Intern positions are available. |
+|[Millennium Space Systems](https://millenniumspace.applytojob.com/apply/V0pEqZ8oC3/Summer-2021-Internship-Non-Engineering)| El Segundo, CA | Applicants MUST be U.S. citizens and eligible for a security clearance. Additionally, applicants must be willing to apply for and maintain a security clearance. |
+|[NISC](https://boards.greenhouse.io/nisc)| Lake St. Louis, MO; Mandan, ND; Cedar Rapids, IA | [Database Conversion Programming](https://boards.greenhouse.io/nisc/jobs/2530733), [Software Development](https://boards.greenhouse.io/nisc/jobs/2338464) and other Intern positions are available. |
+|[Corsair](https://phg.tbe.taleo.net/phg02/ats/careers/v2/viewRequisition?org=CORSAIRMEMORY&cws=37&rid=5952)| Fremont, CA | |
+|[Quantum Health](https://jobs.jobvite.com/quantum-health/search?c=&l=&t=&q=Intern)| Dublin, OH | [IT - Application Developer](https://jobs.jobvite.com/quantum-health/job/oUxfefwE), [IT - QA Ensurance](https://jobs.jobvite.com/quantum-health/job/opwfefw8), [Data Engineering](https://jobs.jobvite.com/quantum-health/job/ocFfefw4) and other Intern positions are available. Some positions require applicants to be legally authorized to work in the United States on a permanent and ongoing future basis without requiring sponsorship. |
+|[The Boring Company](https://jobs.lever.co/boringcompany/41bed6a1-0d01-4fe1-88e2-c1f2c685bf1f)| Las Vegas, NV | |
+|[Cboe Global Markets](https://cboe.wd1.myworkdayjobs.com/External_Career_CBOE/0/refreshFacet/318c8bb6f553100021d223d9780d30be)| NYC; Various | [North American Equities](https://cboe.wd1.myworkdayjobs.com/en-US/External_Career_CBOE/job/New-York-NY/Internship---North-American-Equities_R-1109), [Market Data & Access Services](https://cboe.wd1.myworkdayjobs.com/en-US/External_Career_CBOE/job/New-York-NY/Internship---Market-Data---Member-Services_R-1111) and other Intern positions are available. |
+|[Swiss Re](https://careers.swissre.com/search/?createNewAlert=false&q=2021&locationsearch=&optionsFacetsDD_shifttype=&optionsFacetsDD_customfield2=&optionsFacetsDD_location=&optionsFacetsDD_customfield4=&optionsFacetsDD_customfield5=)| Armonk, NY | [DevOps & Cloud Engineer](https://careers.swissre.com/job/Armonk-NY-10504/637584601/), [Data Engineering](https://careers.swissre.com/job/Armonk-Data-Analytics-Summer-Intern-NY-10504/637586101/) Intern positions are available. |
+|[TransUnion](https://transunion.wd5.myworkdayjobs.com/en-US/transunion/job/Chicago-Illinois/Data-Science---Analytics-Internship--Summer-2020-_19006431)| Chicago, IL | |
+|[Inovalon](https://www.inovalon.com/careers/openings/)| Bowie, MD, Canonsburg, PA | [Cyber Security & Security Operations](https://www.inovalon.com/job/?gh_jid=4258188003), [Software Engineering (.NET)/C#](https://www.inovalon.com/job/?gh_jid=4273220003) and other Intern positions are available. |
+|[Chobani](https://jobs.jobvite.com/chobani/job/ooegefwQ)| Remote (USA) | Information Security Intern |
+|[Liquidnet](https://liquidnet.wd1.myworkdayjobs.com/Liquidnet/5/refreshFacet/318c8bb6f553100021d223d9780d30be)| New York | [Web Development Intern](https://liquidnet.wd1.myworkdayjobs.com/en-US/Liquidnet/job/New-York/Web-Development-Intern---Summer-2021_R-00906), [Global Trading Technology Development Intern](https://liquidnet.wd1.myworkdayjobs.com/en-US/Liquidnet/job/New-York/Global-Trading-Technology-Development-Intern---Summer-2021_R-00905), [Product Intern](https://liquidnet.wd1.myworkdayjobs.com/en-US/Liquidnet/job/New-York/Product-Intern--Equities---Summer-2021_R-00914), [ETS Infrastructure Intern](https://liquidnet.wd1.myworkdayjobs.com/en-US/Liquidnet/job/New-York/ETS-Infrastructure-Intern---Summer-2021_R-00910), [Data Science Intern](https://liquidnet.wd1.myworkdayjobs.com/en-US/Liquidnet/job/New-York/Data-Science-Intern---Summer-2021_R-00903) and other positions |
+|[West Monroe](https://www.wayup.com/i-Management-Consulting-j-Consulting-Intern-Technology-Software-Engineering-West-Monroe-343650435193811/)| Chicago, IL | Must be legally authorized to work in the United States without limitation |
+|[T. Rowe Price](https://troweprice.wd5.myworkdayjobs.com/en-US/TRowePrice/job/Owings-Mills-MD/XMLNAME-2021-Summer-Internship--Global-Technology_48156)| Owings Mills, MD | Global Technology Internship |
+|[Nasdaq](https://www.wayup.com/organizations/nasdaq-8jvMa5/)| Boston, MA ; New York, NY ; Rockville, MD | [SWE](https://www.wayup.com/i-Internet-j-2021-Summer-Internship-Software-Engineering-Intern-Nasdaq-6474413560062/), [Data Science](https://www.wayup.com/i-Internet-j-2021-Summer-Internship-Data-Science-Intern-Nasdaq-627868139928711/), [Information Security](https://www.wayup.com/i-Internet-j-2021-Summer-Internship-Information-Security-Intern-Nasdaq-435398399318626/), [Technical Operations Analysis](https://www.wayup.com/i-Internet-j-2021-Summer-Technical-Operations-Analysis-Intern-Nasdaq-52267876827468/) internships and more |
+|[Flexport](https://boards.greenhouse.io/flexport/jobs/2551356)|San Francsico, [Chicago](https://boards.greenhouse.io/flexport/jobs/2545484), [Bellevue](https://boards.greenhouse.io/flexport/jobs/2551354)|Software Engineering Internship|
+[Wealthsimple](https://jobs.lever.co/wealthsimple/331907f7-49bb-4a60-ad94-8df989e9de0e)|Toronto or Remote (Canada)|[Software Engineering Co-op](https://jobs.lever.co/wealthsimple/331907f7-49bb-4a60-ad94-8df989e9de0e)|
+[Pixlee](https://www.pixlee.com/careers?gh_jid=2266918&gh_src=57e563321us)|Toronto|[Software Engineering](https://www.pixlee.com/careers?gh_jid=2266918&gh_src=57e563321us) Co-op|
+[BMO](https://bmo.wd3.myworkdayjobs.com/en-US/External/job/Toronto-ON-CAN/Software-Developer--Summer-2021--Co-op-Internship----12-Months_R200016601-2)|Toronto|[Software Developer](https://bmo.wd3.myworkdayjobs.com/en-US/External/job/Toronto-ON-CAN/Software-Developer--Summer-2021--Co-op-Internship----12-Months_R200016601-2) Internship starts in the summer, but is 12 months long|
+|[Verizon Media](https://vzbuilders.wd5.myworkdayjobs.com/careers/9/refreshFacet/318c8bb6f553100021d223d9780d30be?source=Linkedin)| Dulles, VA; Champaign, IL | [Software Engineering](https://vzbuilders.wd5.myworkdayjobs.com/en-US/careers/job/US---Dulles/Software-Engineering-Intern_JR0015107?source=Linkedin), [Research Scientist](https://vzbuilders.wd5.myworkdayjobs.com/en-US/careers/job/US---Champaign/Research-Scientist-Intern_JR0015136?source=Linkedin), [Backend Engineer](https://vzbuilders.wd5.myworkdayjobs.com/en-US/careers/job/US---Champaign/Backend-Engineer-Summer-Intern--Data-Team_JR0015196?source=Linkedin) and other Intern positions are available. |
+|[ClickTime](https://www.linkup.com/search/results?keyword=Software+Development+Intern+%28Summer+2021%29&location=&all=&none=&title_contains=&company=&company_ids=)| Various | [Software Development](https://www.linkup.com/details/7e9fcb37c17a9dd12ee1e14e5c9d2ca4), [DevOps](https://www.linkup.com/details/bf195428efa2ee10a2327b0cc80feea4), [BioStatistics](https://www.linkup.com/details/ff9a8a5b9ae2bccb17cd5cdb7a47161c) and other Intern positions are available. |
+|[Podium](https://boards.greenhouse.io/podium81/jobs/1980037?t=8b0de3d81)| Lehi, UT; Remote | Applicant must have authorization to work in the United States. |
+|[Cox Automotive](https://jobs.coxenterprises.com/job/12238391/software-engineering-intern-austin-tx/)| Remote (US) | This is an advertisement for multiple jobs that will be posted soon. Internship is not eligible for sponsorship. |
+|[Miso Robotics](https://misorobotics.applytojob.com/)| Pasadena, CA | [Software Engineering](https://misorobotics.applytojob.com/apply/hVVZGkWneE/Software-Engineer-Intern), [Machine Learning Engineer](https://misorobotics.applytojob.com/apply/13wGgT1gGz/Machine-Learning-Engineer-Intern) and other Intern positions are available. |
+|[ChronoSphere](https://boards.greenhouse.io/chronosphere/jobs/4318564003) | Seattle, NYC, Remote | |
+|[Intuit](https://jobs.intuit.com/job/plano/software-engineer-intern/27595/18612287)| Mountain View, San Diego, CA; Plano, TX | |
+|[MiTek](https://mii.wd5.myworkdayjobs.com/MiTek/0/refreshFacet/318c8bb6f553100021d223d9780d30be)| Greenwood Village, CO; Chesterfield, MO | [Software Developer](https://mii.wd5.myworkdayjobs.com/en-US/MiTek/job/Greenwood-Village-CO-USA/Software-Engineer-Intern---Summer-2021_R00454), [IT Application Security](https://mii.wd5.myworkdayjobs.com/en-US/MiTek/job/Greenwood-Village-CO-USA/IT-Application-Security-Intern_R00468-2), [Software Quality Analyst](https://mii.wd5.myworkdayjobs.com/en-US/MiTek/job/Greenwood-Village-CO-USA/Software-Quality-Analyst-Intern_R00452-1) and other Intern positions are available. |
+|[Bandwidth](https://www.bandwidth.com/careers/internship/) | Raleigh, NC |[SDE](https://www.bandwidth.com/careers/openings/?gh_jid=2433277), [PM](https://www.bandwidth.com/careers/openings/?gh_jid=2472465), [IT](https://www.bandwidth.com/careers/openings/?gh_jid=2612412), [Business Analytics](https://www.bandwidth.com/careers/openings/?gh_jid=2472412) and other internship positions available |
+|[Palo Alto Networks](https://jobs.paloaltonetworks.com/job-search-results/?keyword=Intern&compliment=Americas)| Santa Clara, CA | [Software Intern SDWAN](https://jobs.paloaltonetworks.com/job/11959619/intern-software-intern-sdwan-santa-clara-ca/), [Security Software Engineer](https://jobs.paloaltonetworks.com/job/12186469/intern-security-software-engineer-santa-clara-ca/), [Automation Engineer](https://jobs.paloaltonetworks.com/job/12012103/intern-automation-engineer-santa-clara-ca/) and other Intern positions are available. Applicant must have the authorization to work within the United States. |
+|[Weights & Biases](https://www.diversifytech.co/job-board/machine-learning-engineer---intern-weights--biases)| Remote - Anywhere | Feb 22 - Deadline to apply |
+|[Teampay](https://boards.greenhouse.io/teampay/jobs/5068771002) | New York, NY | |
+|[Medisend](https://www.linkedin.com/jobs/view/2378294159/) | Remote / San Francisco Bay Area | |
+|[Peloton](https://boards.greenhouse.io/peloton/jobs/2666691) | New York, NY | |
+|[Surescripts](https://surescripts.wd1.myworkdayjobs.com/en-US/surescriptscareers/job/Raleigh-North-Carolina/Software-Engineering-Intern_REQ1277) | Raleigh, NC | |
+|[Charito](https://jobs.lever.co/chartio/141f51a4-4603-443e-823b-b77d479cfb99?utm_source=linkup&utm_medium=referrer) | San Francisco, CA | |
+|[Lob](https://www.lob.com/careers/job?2613767)| Various; Remote | Applicant must be eligible to work in the United States. Lob is not able to sponsor Visas for this role. |
+|[Medidata](https://jobs.jobvite.com/medidata-solutions/job/or0oefwN/apply) | New York, NY; San Francisco, CA; Iselin, New Jersey | |
+|[Myst AI](https://jobs.lever.co/myst.ai/)| San Francisco, CA | [Data Science](https://jobs.lever.co/myst.ai/0b00ce01-a6d2-42c6-a06d-a4629cfbe7a4), [Software Engineering](https://jobs.lever.co/myst.ai/a8213a4b-e210-43a7-83ed-05771c178b15) Intern positions are available. |
+|[Tinder](https://jobs.lever.co/matchgroup/290d9f50-b41a-4f98-bb09-f640a43369d5) | Los Angeles, CA | Machine Learning, [Security](https://jobs.lever.co/matchgroup/fee1e1ae-62e0-48a5-a97e-8b49572a9f24), [Data Engineering](https://jobs.lever.co/matchgroup/2e13655d-964d-4508-9526-41a3b3bdb2c3) |
+|[Ibotta](https://ibotta.ruutly.com/job/2640088)| Denver, CO; Remote | Applicants must be currently authorized to work in the United States on a full-time basis. |
+|[HBO](https://www.showbizjobs.com/internships/hbo-summer-virtual-intern-software-engineer-in-new-york/jid-d8v42m/amp) | Remote | |
+|[CVS Health](https://jobs.cvshealth.com/search-results?CloudSearchValue=undergrad%20intern&CloudSearchLocation=none&CloudSearchRadius=20&radiusUnit=Miles&prefilters=none) | Remote | [SWE](https://jobs.cvshealth.com/ShowJob/JobId/1037929/Software-Engineering-Internship-Undergrad), [IT Architecture](https://jobs.cvshealth.com/ShowJob/JobId/1012410/ITArchitectureInternshipUndergraduate), [Digital](https://jobs.cvshealth.com/ShowJob/JobId/1049438/DigitalInternshipUndergrad) and more positions available |
+|[Blue Cross Blue Shield of Massachusetts](https://bcbsma.wd5.myworkdayjobs.com/BCBSMA/1/refreshFacet/318c8bb6f553100021d223d9780d30be?source=Linkedin)| Remote | [Automation](https://bcbsma.wd5.myworkdayjobs.com/en-US/BCBSMA/job/Boston/Automation-Summer-Intern_R03658-1), [Security (IT)](https://bcbsma.wd5.myworkdayjobs.com/en-US/BCBSMA/job/Quincy/Security-Summer-Intern_R03651-1), [Data Engineer](https://bcbsma.wd5.myworkdayjobs.com/en-US/BCBSMA/job/Quincy/Data-Engineer-Summer-Intern_R03661-1) and other Intern positions are available. Must be able to work remotely during hours that align to BCBSMA’s workday. |
+|[Sailthru](https://boards.greenhouse.io/sailthru/jobs/2926837)| New York (Remote) | |
+|[Glassdoor](https://www.glassdoor.com/Jobs/Glassdoor-Jobs-E100431.htm)| Remote | [Machine Learning](https://www.glassdoor.com/job-listing/machine-learning-intern-glassdoor-JV_IC1139761_KO0,23_KE24,33.htm?jl=4007383231&pos=103&ao=1001675&s=21&guid=00000177d0a061eb8682d7cd4b8e0dff&src=GD_JOB_AD&ei=100431&t=ESR&extid=2&exst=E&ist=L&ast=EL&vt=w&slr=true&ea=1&cs=1_5f96761b&cb=1614112908981&jobListingId=4007383231&ctt=1614113869844&srs=EI_JOBS), [Data Engineering](https://www.glassdoor.com/partner/jobListing.htm?pos=105&ao=1001675&s=21&guid=00000177d0a061eb8682d7cd4b8e0dff&src=GD_JOB_AD&ei=100431&t=ESR&extid=2&exst=E&ist=L&ast=EL&vt=w&slr=true&ea=1&cs=1_7385207f&cb=1614112909010&jobListingId=4006472254), [Software Engineer](https://www.glassdoor.com/partner/jobListing.htm?pos=107&ao=1001675&s=21&guid=00000177d0a061eb8682d7cd4b8e0dff&src=GD_JOB_AD&ei=100431&t=ESR&extid=2&exst=E&ist=L&ast=EL&vt=w&slr=true&ea=1&cs=1_0ebf5007&cb=1614112909058&jobListingId=4010646191) and other Intern positions are available. |
+|[Petal](https://jobs.lever.co/petalcard/26e73f8f-affc-4db1-8468-920873f443d5) | NYC/Remote | |
+|[Applied Systems](https://globalcareers-appliedsystems.icims.com/jobs/search?ss=1&searchKeyword=Intern)| Remote | [Software Developer](https://canada-appliedsystems.icims.com/jobs/3656/software-development-intern/job?hub=15), [Software Developer In Test](https://canada-appliedsystems.icims.com/jobs/3655/software-engineer-in-test-intern/job?hub=15) Intern positions are available. Interested applicants must reside in the United States or Canada. Some positions require applicant to be authorized to work in the United States without sponsorship. |
+|[Cresta](https://jobs.lever.co/cresta/f8aa52ad-0dc8-43e1-b5ba-526e3971f053) | SF | ML Internship|
+|[Truera](https://jobs.lever.co/ailens/58160497-fcba-41d8-b952-67832c34df94) | Remote | Front End |
+|[Mindgrub](https://www.mindgrub.com/careers) | Baltimore, MD | Web Developer (Intern), Mobile Developer (Intern), UX Designer(Intern) |
+|[Washington Post](https://washpost.wd5.myworkdayjobs.com/en-US/washingtonpostcareers/job/DC-Washington-TWP-Headquarters/XMLNAME-2021-Summer-Intern_JR-90272151) | Washington DC | SWE Summer Intern 2021 |
+|[Malwarebytes](https://jobs.malwarebytes.com/job/2967812) | Clearwater, FL | |
+|[NimbleRx](https://jobs.lever.co/nimblerx/1c84caa8-e995-4239-a172-2e6a223c829c) | Redwood City, CA| |
+|[Cohesity](https://www.cohesity.com/company/careers/open-positions/?gh_jid=2640898) | San Jose, CA| |
+|[Waybridge](https://waybridge.com/careers?gh_jid=4409662003) | Remote | |
+
+Huge shout-out to our contributors! Fill [this survey](https://bit.ly/3d5O76c), make a [Pull Request](https://github.com/susam/gitpr#create-pull-request), or submit [an issue](https://github.com/Pitt-CSC/Summer2021-Internships/issues) if you'd like to contribute too! 🙏
+* [GintasS](https://github.com/GintasS) 🐐
+* [ankasengupta](https://github.com/ankasengupta) 🐐
+* [ShreyShah977](https://github.com/ShreyShah977)
+* [hjs2000cn](https://github.com/hjs2000cn)
+* [ctcuff](https://github.com/ctcuff)
+* [JasperCheung](https://github.com/JasperCheung)
+* [ray7yu](https://github.com/ray7yu)
+* [kaleidoscoperope](https://github.com/kaleidoscoperope)
+* [bwubrian](https://github.com/bwubrian)
+* [warfororks](https://github.com/warfororks)
+* [5CoolKids](https://github.com/5CoolKids)
+* [wcygan](https://github.com/wcygan)
+* [phucks0612](https://github.com/phucks0612)
+* [slingam00](https://github.com/slingam00)
+* [spencerng](https://github.com/spencerng)
+* [julianzhao0101](https://github.com/julianzhao0101)
+* [Gopal6600](https://github.com/Gopal6600)
+* [arpansahoo](https://github.com/arpansahoo)
+* [gabriel-flynn](https://github.com/gabriel-flynn)
+* [arjun-dureja](https://github.com/arjun-dureja)
+* [simranthomas](https://github.com/simranthomas)
+* [noo-rain](https://github.com/noo-rain)
+* [anishganti](https://github.com/anishganti)
+* [ApurvShah007](https://github.com/ApurvShah007)
+* [Sherlemious](https://github.com/Sherlemious)
+* [JackGoldsworth](https://github.com/JackGoldsworth)
+* [anh212](https://github.com/anh212)
+* [Abhishek-AC](https://github.com/Abhishek-AC)
+* [agamjolly](https://github.com/agamjolly)
+* [iiradia](https://github.com/iiradia)
+* [baoalvin1](https://github.com/baoalvin1)
+* [qhb1001](https://github.com/qhb1001)
+* [bwaits2](https://github.com/bwaits2)
+* [garciajess](https://github.com/garciajess)
+* [zejunliu](https://github.com/zejunliu)
+* [coffeeologist](https://github.com/coffeeologist)
+* [rashmi-ravishankar](https://github.com/rashmi-ravishankar)
+* [BaruYogesh](https://github.com/BaruYogesh)
+* [samjoffe](https://github.com/samjoffe)
+* [nchan9](https://github.com/nchan9)
+* [greyfertich](https://github.com/greyfertich)
+* [shubhra-bedi](https://github.com/shubhra-bedi)
+* [zarif98](https://github.com/zarif98)
+* [tuankiet65](https://github.com/tuankiet65)
+* [Priyandubey](https://github.com/Priyandubey)
+* [FerruccioSisti](https://github.com/FerruccioSisti)
+* [MattChen2000](https://github.com/MattChen2000)
+* [jain1407](https://github.com/jain1407)
+* [gitgm3hta](https://github.com/gitgm3hta)
+* [justnguyen1](https://github.com/justnguyen1)
+* [SahasGoli](https://github.com/SahasGoli)
+* [trhiana](https://github.com/trhiana)
+* [aaronw4ng](https://github.com/aaronw4ng)
+* [rohit-ganguly](https://github.com/rohit-ganguly)
+* [azharichenko](https://github.com/azharichenko)
+* [varughese](https://github.com/varughese)
+* [zmwang622](https://github.com/zmwang622)
+* [rubywerman](https://github.com/rubywerman)
+* [stefantobler](https://stefantobler.com)
+* [danerwilliams](https://github.com/danerwilliams)
+* [kimjuyounglisa](https://github.com/kimjuyounglisa)
+* [Leundai](https://github.com/Leundai)
+* [aidev1065](https://github.com/aidev1065)
+* [zhixiangteoh](https://github.com/zhixiangteoh)
+* [christopherhui](https://github.com/christopherhui)
+* [jamiepinheiro](https://github.com/jamiepinheiro)
+* [michaelfromyeg](https://github.com/michaelfromyeg)
+* [tuankiet65](https://github.com/tuankiet65)
+* [StefanTobler](https://github.com/StefanTobler)
+* [SahilSudhir](https://github.com/Pantharex)
+* [Sahir1234](https://github.com/Sahir1234)
+* [mneskovic](https://github.com/mneskovic)
+* [prithvikannan](https://github.com/prithvikannan)
+* [sunschong](https://github.com/sunschong)
+* [priyansdesai](https://github.com/priyansdesai)
+* [carolksun](https://github.com/carolksun)
+* [amanuel2](https://github.com/amanuel2)
+* [camless](https://github.com/camless)
+* [ayoung19](https://github.com/ayoung19)
+* [aabosh](https://github.com/aabosh)
+* [maxgravitte](https://github.com/maxgravitte)
+* [jphui](https://jhui.gq)
+* [fatimazali](https://github.com/fatimazali)
+* [Gamebot2](https://github.com/Gamebot2)
+* [rosescript](https://github.com/rosescript)
+* [jshin313](https://github.com/jshin313)
+* [EParmar18](https://github.com/EParmar18)
+* [CuriousIbrahim](https://github.com/CuriousIbrahim)
+* [Kur0Leo](https://github.com/Kur0Leo)
+* [GarlicDebug](https://github.com/GarlicDebug)
+* [Howardma31](https://github.com/Howardma31)
+* [aakash1104](https://github.com/aakash1104)
+* [ekluthra](https://github.com/ekluthra)
+
+Thanks to [elaine-zheng](https://github.com/elaine-zheng/summer2020internships) for the inspiration! 🐐

--- a/archived/README-2021.md
+++ b/archived/README-2021.md
@@ -1,4 +1,7 @@
 # Summer 2021 Internships ☀️👩‍💻
+> **Note:**
+> This README was taken from [this commit in this repository](https://github.com/pittcsc/Summer2024-Internships/tree/552701f413a0ad84a90164b03e7eee9c902ab37a).
+
 **In the coming days/weeks we will be transitioning this repository to a Summer 2022 one. If you have any ideas on how we can improve the repo, please let us know by creating an issue**
 
 Use this repo to share and keep track of any tech-related internships. For a [Google Sheet 📝 version of this repo (that remains in sync with this table) click here](https://docs.google.com/spreadsheets/d/1bJq7YQV19TWyzPCBeQi5P4uOm8uiAAm2AHCnVNGRIDg/edit#gid=0)! For more tips on the internship process check out the [Zero to Offer 📈 program here](https://www.pittcs.wiki/zero-to-offer).

--- a/archived/README-2022.md
+++ b/archived/README-2022.md
@@ -1,4 +1,7 @@
 # Summer 2022 Tech Internships by Pitt CSC 🤿👩‍💻
+> **Note:**
+> This README was taken from [this commit in this repository](https://github.com/pittcsc/Summer2024-Internships/tree/a8d1b7780faa18fd2d13669ddab3a761023964d2).
+
 Use this repo to share and keep track of software, tech, CS, PM, quant internships for Summer 2022. List maintained by [the Pitt Computer Science Club](https://pittcsc.org/)!
 
 ---

--- a/archived/README-2022.md
+++ b/archived/README-2022.md
@@ -1,0 +1,476 @@
+# Summer 2022 Tech Internships by Pitt CSC 🤿👩‍💻
+Use this repo to share and keep track of software, tech, CS, PM, quant internships for Summer 2022. List maintained by [the Pitt Computer Science Club](https://pittcsc.org/)!
+
+---
+
+<div align="center">
+	<p>
+		<a href="https://simplify.jobs/?utm_source=pittcsc&utm_medium=internships_repo">
+			<b>Applying to internships?</b>
+			<br>
+			Autofill all your applications in a single click.
+			<br>
+			<div>
+				<img src="https://res.cloudinary.com/dpeo4xcnc/image/upload/v1636594918/simplify_pittcsc.png" width="450"  alt="Simplify">
+			</div>
+		</a>
+		<sub><i>Stop manually re-entering your information. Simplify’s extension helps you autofill internship applications on millions of sites.</i></sub>
+	</p>
+</div>
+
+---
+
+:warning: **This repository is only for internships/co-ops in the United States, Canada or for Remote positions:earth_americas:.**
+
+ 📈 For tips on the internship process check out the [Zero to Offer program here](https://www.pittcs.wiki/zero-to-offer).  📈
+
+🎓 Check out our New Grad repo [here](https://github.com/coderQuad/New-Grad-Positions-2022).
+
+🤗 **Contribute by submitting a [pull request](https://github.com/susam/gitpr#create-pull-request) or [filling out this form](https://bit.ly/3d5O76c)!**  🤗
+
+## The List 👔
+
+| Name  |  Location |  Notes |
+|---|---|-------------|
+|[Teachers Pay Teachers](https://boards.greenhouse.io/teacherspayteachers/jobs/4105276) | NYC or remote | Full stack software engineering internship - remote OK
+|[Expensify](https://we.are.expensify.com/apply#workwithus) | Anywhere | Full stack software engineering internship - remote work and visa sponsorship available. |
+|[Motional](https://motional.com/careers) | Boston, Pittsburgh, Santa Monica, Singapore | A self driving car company.|
+|<del>Gusto</del> | | **Closed** |
+|<del>Hudson River Trading</del> | | **Closed** |
+|<del>Bridgewater Associates</del> | | **Closed** |
+|<del>Credit Suisse</del> | | **Closed** |
+|<del>BlackStone</del> | | **Closed** |
+|<del>PWC</del> | | **Closed** |
+|[AQR](https://careers.aqr.com/jobs/department/university-jobs#/) | Greenwich, CT | Research, Portfolio Implementation |
+|[Optiver](https://www.optiver.com/working-at-optiver/career-opportunities/?filter-level=internship) | Various | Positions in Software Engineering and Trading. Will not sponsor individuals for employment authorization for these job openings. |
+| <del> Caterpillar </del> |  | **Closed** |
+|[Schneider Downs](https://schneiderdowns.csod.com/ats/careersite/JobDetails.aspx?id=474&site=4) | Pittsburgh, PA | IT Intern, Cybersecurity Intern. |
+|[GE](https://jobs.gecareers.com/global/en/search-results) | Various | [GE Aviation Aviation Systems](https://jobs.gecareers.com/global/en/job/R3560419/GE-Aviation-Aviation-Systems-Intern-Summer-2022), [GE Gas Power Digital Technology](https://jobs.gecareers.com/global/en/job/R3558732/Gas-Power-Digital-Technology-Intern-2022) and other Intern positions are available. Some roles are restricted to U.S. persons only or those who are legally authorized to work in the United States. |
+|[Second Order Effects](https://boards.greenhouse.io/soeffects/jobs/4311435003) | El Segundo, CA | Applicant must be a U.S. citizen or eligible to obtain the required authorizations from the U.S. Department of State. |
+|<del>Morgan Stanley</del> | NYC | **Closed** |
+|<del>Bessemer Ventures Fellowship</del> | Various | **Closed** |
+|<del>Audible</del> | |  **Closed** |
+|[KeyBank](https://keybank.wd5.myworkdayjobs.com/External_Career_Site/1/refreshFacet/318c8bb6f553100021d223d9780d30be?source=Keydotcom) | Various | [Enterprise Security](https://keybank.wd5.myworkdayjobs.com/en-US/External_Career_Site/job/Plymouth-Meeting-PA/Summer-2022-Key-Technology--Operations---Services--Internship--Enterprise-Security-Track-_R-755?source=Keydotcom), [Enterprise Payments](https://keybank.wd5.myworkdayjobs.com/en-US/External_Career_Site/job/Cleveland-OH/XMLNAME-2022-Enterprise-Payments-Summer--Intern_R-743?source=Keydotcom), [Technology](https://keybank.wd5.myworkdayjobs.com/en-US/External_Career_Site/job/Buffalo-NY/Summer-2022-Key-Technology--Operations---Services--Internship--Technology-Track-_R-751?source=Keydotcom) and other Intern positions are available. Some positions may NOT be eligible for employment visa sponsorship for non-U.S. citizens. |
+|[General Motors](https://generalmotors.wd5.myworkdayjobs.com/Careers_GM/0/refreshFacet/318c8bb6f553100021d223d9780d30be)| Warren, MI | [Hardware Engineering](https://generalmotors.wd5.myworkdayjobs.com/en-US/Careers_GM/job/Warren-Michigan-United-States-of-America/Global-Product-Development---Hardware-Engineering-Internship-Program_JR-000045485), [Software Engineering](https://generalmotors.wd5.myworkdayjobs.com/en-US/Careers_GM/job/Warren-Michigan-United-States-of-America/Global-Product-Development---Software-Engineering-Internship-Program_JR-000045488) Intern positions are available. Please only apply if you do not need sponsorship to work in the United States now or in the future. We are unable to consider candidates who require sponsorship. |
+|<del>Susquehanna (SIG)</del> | | **Closed** |
+|<del>Five Rings</del> | | **Closed** |
+|[Akuna Capital](https://akunacapital.com/careers?&experience=intern&search_term=#careers) | Chicago, Boston | Software, Trading, Quant Internships. Legal authorization to work in the U.S. is required. |
+|[D. E. Shaw](https://www.deshaw.com/careers/software-developer-intern-new-york-4239) | NYC | Software, Trading, Quant, System Internships |
+|<del>Toyota Connected</del> | Plano, Texas | **Closed**
+|[Vanguard](https://www.vanguardjobs.com/job-search-results/?keyword=college%20to%20corporate&level[]=Student%20%26%20Recent%20Graduates) | Various | App Dev, Security & IT internships
+|<del>Salesforce</del>| | **Closed** |
+|<del>RBC Capital Markets</del> | | **Closed** |
+|[Arrowstreet Capital](https://arrowstreetcapital.wd5.myworkdayjobs.com/Arrowstreet/0/refreshFacet/318c8bb6f553100021d223d9780d30be) | Boston, MA | Quant |
+|<del>Asana</del> | | **Closed** |
+|<del>Target</del> | | **Closed** |
+|<del>BNP Paribas</del> | | **Closed** |
+|[MealMe](https://www.mealme.ai/software-internship) | Not displayed | See positions [here](https://www.mealme.ai/careers) |
+|[Apple](https://jobs.apple.com/en-us/details/200253195/software-engineering-internship?team=STDNT) | Cupertino, CA | [ML/AI Internship](https://jobs.apple.com/en-us/details/200253211/machine-learning-ai-internship?team=STDNT) |
+|[Meta](https://www.facebook.com/careers/v2/jobs/946116176191468/)| Various| SWE Internship/Co-op, [FBU](https://www.facebook.com/careers/FBUEngineering) |
+|[Goldman Sachs](https://www.goldmansachs.com/careers/students/programs/americas/summer-analyst-program.html)| Various| Summer Analyst Program |
+|<del>BlackRock</del>| | **Closed** |
+|[Bank of America](https://bankcampuscareers.tal.net/vx/brand-4/candidate/so/pm/1/pl/1/opp/7140-Global-Technology-Summer-Analyst-Program-2022/en-GB)| Various| **Closed** |
+|[Two Sigma](https://careers.twosigma.com/careers/JobDetail?jobId=8471) | Houston, NYC | SWE Internship and Quant Research roles. |
+| <del> Cigna </del> |  | **Closed** |
+| <del> Bracebridge Capital </del> |  | **Closed** |
+| <del> Federated Insurance </del> |  | **Closed** |
+| <del> US Ventures </del> |  | **Closed** |
+|[Cadre](https://boards.greenhouse.io/cadre) | NYC | Product |
+|[Amazon/AWS](https://www.amazon.jobs/en/search?base_query=Summer+2022&loc_query=&latitude=&longitude=&loc_group_id=&invalid_location=false&country=&city=&region=&county=) | Various | [Software Development Engineer](https://www.amazon.jobs/en/jobs/1557929/software-development-engineer-internship-summer-2022-us), [Cloud Support Associate](https://www.amazon.jobs/en/jobs/1608042/cloud-support-associate-intern-summer-2022-us), [Assoc Customer Solutions Manager](https://www.amazon.jobs/en/jobs/1609945/assoc-customer-solutions-manager-intern-summer-2022-us), [Quality Assurance Engineer](https://www.amazon.jobs/en/jobs/1628670/quality-assurance-engineer-internship-summer-2022-us), [Security Engineer](https://www.amazon.jobs/en/jobs/1628641/security-engineer-internship-summer-2022-us) and other Intern positions are available. |
+|[Palantir](https://jobs.lever.co/palantir?commitment=Internship)| Various | [Forward Deployed Software Engineer](https://jobs.lever.co/palantir/e6ff8bf2-135e-474d-ad37-24f490ae1dd2), [Software Engineer](https://jobs.lever.co/palantir/bdcfb29f-4f27-42de-933f-7f83a359b9f0), [Palantir Path](https://jobs.lever.co/palantir/667ad245-0eb8-44da-b29c-791c2fa081d3) Intern positions are available. |
+|[Tableau](https://salesforce.wd1.myworkdayjobs.com/en-US/Tableau/job/Washington---Seattle/Summer-2022-Intern---Tableau-Software-Engineer_JR103736) | Seattle, Austin, Palo Alto, SF | |
+|<del>McKinsey</del> | | **Closed** |
+|[Nvidia](https://nvidia.wd5.myworkdayjobs.com/en-US/NVIDIAExternalCareerSite/job/US-MI-Remote/High-Performance-Computing-Engineer-Intern---Summer-2022_JR1943862-2?source=jobboardlinkedin) | US, MI, Remote | Search `2022` for more positions |
+|[Cisco](https://jobs.cisco.com/jobs/SearchJobs/Summer%202022) | Chicago, IL; San Francisco, CA | [Network Support Engineer](https://jobs.cisco.com/jobs/ProjectDetail/Network-Support-Engineer-Intern-Summer-2022-Internship-Bachelors-Meraki/1339621?source=LinkedIn), [Product Software Engineer](https://jobs.cisco.com/jobs/ProjectDetail/Product-Software-Engineer-Summer-2022-Internship-Meraki/1339636?source=LinkedIn) Intern positions are available. |
+|[Tower Research Capital](https://www.tower-research.com/open-positions) | Chicago, NYC | Quant Intern positions are available. |
+| <del> Jane Street </del> |  | **Closed** |
+|[PayPal](https://jobsearch.paypal-corp.com/en-US/search?keywords=intern&facetcountry=us&location=&facetcategory=internship) | Various | Software Engineer Intern, Product Manager Intern, Product Manager MBA Intern, Risk Management Intern, Finance & Accounting Intern, Data Analyst Intern positions are available. Must reside in the U.S. during the Summer internship program and must be able to obtain authorization to work in the U.S. for the summer. |
+|[Barclays](https://search.jobs.barclays/search-jobs/Summer%202022/United%20States/22545/1/2/6252001/39x76/-98x5/0/2) | Various | QA, Developer Analyst, Data Analytics and other Intern positions are available. Some positions require unrestricted U.S. work authorization. |
+|[Lenovo](https://jobs.lenovo.com/en_US/careers/SearchJobs/Summer%202022?8635=%5B488%5D&8635_format=3279&listFilterMode=1&jobRecordsPerPage=10&) | Various | Server Hardware Development, Software Development and other Intern positions are available. |
+|[Belvedere Trading](http://www.belvederetrading.com/jobs/) | Chicago | Software Engineer Intern (Summer and Winter), Junior Hybrid Trader Intern and Junior Trader intern positions are available. |
+|<del>C.H. Robinson</del> | | **Closed** |
+| <del> Benchling </del> |  | **Closed** |
+|[Raymond Corporation](https://recruiting.adp.com/srccar/public/nghome.guid?c=1127807&d=ExternalCareerSite&prc=RMPOD1#/) | Greene, NY | Telematics, Embedded Systems and other Co-op positions are available. Spring Co-op positions are available too. |
+| <del> DRW </del>  |  | **Closed** |
+|[Arconic](https://arconic.referrals.selectminds.com/jobs/it-application-intern-1472) | Pittsburgh | IT|
+|[Oracle](https://eeho.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1/job/102463/?utm_medium=jobshare) | Various | Software Engineer Intern in [Analytics Cloud](https://eeho.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1/job/120866), [Applications Development](https://eeho.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1/job/120868), [Corporate Architechture](https://eeho.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1/job/120880), [Database & Systems Technologies](https://eeho.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1/job/120869), [Global Business Unit](https://eeho.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1/job/120904), [Sophomore](https://eeho.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1/job/120874) and [Junior](https://eeho.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1/job/120872) programs |
+|[Citadel Securities](https://www.citadelsecurities.com/careers/details/software-engineer-intern-us) | Chicago, NYC | |
+|[Microsoft](https://careers.microsoft.com/students/us/en/job/1085294/Software-Engineering-Intern-Opportunities) | Various |
+|[Aldridge Electric](https://aldridge.csod.com/ux/ats/careersite/9/home?c=aldridge) | Libertyville, IL | [IT](https://aldridge.csod.com/ux/ats/careersite/9/home/requisition/553?c=aldridge), [Developer](https://aldridge.csod.com/ux/ats/careersite/9/home/requisition/550?c=aldridge), [Agile](https://aldridge.csod.com/ux/ats/careersite/9/home/requisition/549?c=aldridge) Intern positions are available. |
+|<del>VMware</del> | Various | **Closed** | 
+| <del> Fifth Third Bank </del> |  | **Closed** |
+|[Red Ventures](https://careers.redventures.com/positions.html?team=college&office=&brand=) | Various | Various [Positions](https://www.redventures.com/careers/programs/launch) related to Software Engineer, Business Analyst Internships |
+| <del> Prudential Financial </del> |  | **Closed** |
+|[Pimco](https://careers.pimco.com/careers/FolderDetail/2022-Summer-Tech-Intern-Software-Engineering/30309) | Austin, TX and Newport Beach, CA | |
+|[Collins Aerospace](https://jobs.collinsaerospace.com/search-jobs/Summer%202022?orgIds=1738&kt=1) | Various | SWE, Data Science and other Intern positions are available. Some positions require applicant to be a U.S Citizen/Permanent Resident “Green Card” holder. |
+|[IMC](https://careers.imc.com/us/en/c/internships-jobs) | Chicago, IL | SWE and Quant Roles available. |
+| <del> Dick's Sporting Goods </del> |   | **Closed** |
+|[Citi Bank](https://jobs.citi.com/job/-/-/287/9929719696) | New York City, NY | Quantitative Analysis. Requires unrestricted U.S. work authorization. |
+|<del> Conagra Brands</del> |  | **Closed** |
+|[P&G](https://www.pgcareers.com/search-jobs?k=Intern&ascf=[{%27key%27:%27custom_fields.Language%27,%27value%27:%27English%27},]&alp=6252001&alt=2) | Various | Software Engineer/Data Engineer, IT Analytics and Insights and other Intern positions are available. Will not sponsor work visas for some positions. |
+|<del>Raytheon Technologies</del>|Cedar Rapids, IA| **Closed** |
+| <del> RSM </del> |  | **Closed** |
+|[Freddie Mac](https://careers.freddiemac.com/us/en/job/JR3553/Computer-Science-Intern-Summer-2022) |  McLean, VA | Computer Science Intern position is available. Will not sponsor work visas now or in the future. |
+|<del> Nestle </del> | | **Closed** |
+|[L3Harris Technologies](https://careers.l3harris.com/job/greenville/software-engineering-intern-co-op-greenville-tx-summer-fall-co-op-and-summer-internship-2022/4832/11663221136) | Greenville, TX | SWE Intern position is available. Summer/Fall Co Op is also available. Please be aware many of our positions require the ability to obtain a security clearance (US citizenship required). In addition, applicants who accept a conditional offer of employment may be subject to government security investigation(s) and must meet eligibility requirements for access to classified information. |
+| <del> Peak6 </del> | | **Closed** |
+|<del> Citrix </del>| Various | **Closed** |
+|[Qualtrics](https://www.qualtrics.com/careers/us/en/job/600473/Software-Development-Engineer-in-Test-Summer-Intern) | Seattle, WA; Provo, UT | [Software Development Engineer in Test](https://www.qualtrics.com/careers/us/en/job/600473/Software-Development-Engineer-in-Test-Summer-Intern), [Software Test Engineer](https://www.qualtrics.com/careers/us/en/job/2271786/Software-Test-Engineer-Intern) and other Intern positions are available. Must be legally authorized to work in job location without Qualtrics sponsorship now or in the future. |
+|[Virtu Financial](https://boards.greenhouse.io/virtu/jobs/5432329002) | NYC | Developer Intern position is available. |
+|[Applied Intuition](https://jobs.lever.co/applied/c22805d5-2006-4867-bb32-671951b17206) | SF | |
+|<del>MathWorks</del> | |  **Closed** |
+|[Redfin](https://redfin.wd1.myworkdayjobs.com/en-US/redfin_careers/job/WA---Seattle/Software-Engineer---2022-Internship_41345) | Seattle, WA; San Francisco, CA; Plano, TX | Software Engineer Intern |
+|[Quantco](https://jobs.lever.co/quantco-/d3f46e52-c120-4b25-aee6-bc743daaf6d7?lever-origin=applied&lever-source%5B%5D=GitHub) | Global | |
+|[Virgin Orbit](https://careers-virginorbit.icims.com/jobs/6289/2022-summer-internship---multiple-departments/job?mobile=false&width=1168&height=500&bga=true&needsRedirect=false&jan1offset=-480&jun1offset=-420) | Long Beach, CA | Applicant must be a U.S. citizen, lawful permanent resident of the U.S., protected individual as defined by ITAR (22 CFR §120.15) or eligible to obtain the required authorizations from the U.S. Department of State. |
+| <del> Crestron </del> |  | **Closed** |
+|[JP Morgan](https://jpmc.fa.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001/job/210139653) | Various | More positions [here](https://jpmc.fa.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001/requisitions?keyword=2022&location=United%20States&locationId=300000000289738&locationLevel=country). To be eligible for this program, you must be authorized to work in the U.S. on a permanent basis. We do not offer any type of employment-based immigration sponsorship for this program.|
+| <del> Dropbox </del>  |  | **Closed** |
+|[Cargill](https://careers.cargill.com/search-jobs/Summer%202022/United%20States/23251/1/2/6252001/39x76/-98x5/50/2) | Wayzata, Hopkins, MN | [Software Engineering Intern](https://careers.cargill.com/job/hopkins/software-engineering-internship-summer-2022/23251/12058424688), [Trading Data & Analytics](https://careers.cargill.com/job/wayzata/trading-data-and-analytics-intern-summer-2022/23251/11677499248), [Trading Technology](https://careers.cargill.com/job/hopkins/trading-technology-internship-summer-2022/23251/11677499280) Intern positions. Must have a right to work in the U.S. that is not based solely on possession of a student visa or a visa sponsored by a third-party employer. |
+|<del>Johnson Controls</del>| | **Closed** |
+|<del>HubSpot</del>| | **Closed** |
+|<del>Clever</del> | |  **Closed** |
+|[Robinhood](https://robinhood.com/us/en/careers/openings/) | Menlo Park, CA | [Android Engineer](https://robinhood.com/us/en/careers/openings/?gh_jid=3335146), [Backend Engineer](https://robinhood.com/us/en/careers/openings/?gh_jid=3339166), [Data Scientist, Analytics](https://robinhood.com/us/en/careers/openings/?gh_jid=3335157) and other Intern positions are available. Winter and Fall internships are available too! |
+|<del>Jina AI</del>| | **Closed** |
+| <del>TomTom</del> | | **Closed** |
+|[Walmart](https://walmart.wd5.myworkdayjobs.com/en-US/WalmartExternal/job/US-AR-BENTONVILLE-Home-Office-ISD-Office---DGTC/XMLNAME-2022-Summer-Intern--Software-Engineer-II_R-682495)| Various | [Data Engineer III](https://walmart.wd5.myworkdayjobs.com/en-US/WalmartExternal/job/US-AR-BENTONVILLE-Home-Office-ISD-Office---DGTC/XMLNAME-2022-Summer-Intern--Data-Engineer-III_R-685463), [Software Engineer III](https://walmart.wd5.myworkdayjobs.com/en-US/WalmartExternal/job/US-AR-BENTONVILLE-Home-Office-ISD-Office---DGTC/XMLNAME-2022-Summer-Intern--Software-Engineer-III_R-682538), [Software Engineer II](https://walmart.wd5.myworkdayjobs.com/en-US/WalmartExternal/job/US-AR-BENTONVILLE-Home-Office-ISD-Office---DGTC/XMLNAME-2022-Summer-Intern--Software-Engineer-II_R-682495) Intern positions are available. |
+|Duolingo | | **Closed** |
+|[Nuro.ai](https://www.nuro.ai/careersitem?gh_jid=3356175) | Mountain View, CA | Software Engineer Intern |
+| <del> Capital One </del>|  | **Closed** |
+| <del> Hyperscience </del>|  | **Closed** |
+|[Jump Trading LLC](https://www.jumptrading.com/apply.html?gh_jid=2939637) | Chicago, IL | Software Engineer Intern |
+|<del>Cox Automotive</del> | | **Closed** |
+|[IBM](https://www.ibm.com/us-en/employment/entrylevel/#jobs?%23jobs=&job-category=Software%2520Development%2520%2526%2520Support&experience=Intern) | Various | Various positions including [Data Science intern](https://careers.ibm.com/job/13522697/data-scientist-intern-summer-2022-remote/?codes=IBM_CareerWebSite), [Front End Developer intern](https://careers.ibm.com/job/13542747/front-end-developer-intern-summer-2022-remote/?codes=IBM_CareerWebSite) |
+| <del> Affirm </del> |  | **Closed** |
+|<del>Chapter</del>| | **Closed** |
+|[Okta](https://www.okta.com/company/careers/engineering/software-engineer-intern-us-and-canada-3338724/)| San Francisco, San Jose, CA; Bellevue, WA | Software Engineer Intern; [Auth0 SWE](https://www.okta.com/company/careers/engineering/software-engineer-intern-auth0-3514615/) |
+|[Pearson](https://pearson.jobs/usa/jobs/?q=Intern)| Durham, NC; San Antonio, TX | Software Engineer Intern. Different technology areas are available. |
+|<del>Commerce Bank</del> | | **Closed** |
+|[Garmin](https://careers-us.garmin.com/us/en/internship-jobs) | Olathe, KS | [Software Engineer Intern - Embedded](https://careers-us.garmin.com/us/en/job/21001ET/Software-Engineer-Intern-Embedded-HQ-Olathe-KS), [Software Engineer Intern - Mobile](https://careers-us.garmin.com/us/en/job/21001G1/Software-Engineer-Intern-Mobile-HQ-Olathe-KS), [Software Engineer Intern - Web Development/DevOps](https://careers-us.garmin.com/us/en/job/21001G0/Software-Engineer-Intern-Web-Development-DevOps-HQ-Olathe-KS) Intern positions are available. |
+|<del>Medtronic </del> |  | **Closed** |
+| <del> Aechelon Technology </del> |  | **Closed** |
+|<del>Stripe</del> | San Francisco, Seattle, New York City | **closed** |
+|[UnitedHealth Group](https://careers.unitedhealthgroup.com/job-search-results/?level[]=Student%20Internships) | La Crosse, Wisconsin | Software Engineer Intern, IT Intern. Must be eligible to work in the U.S. without company sponsorship, now or in the future. |
+|[SAP](https://jobs.sap.com/job/Palo-Alto-SAP-iXp-Intern-Software-Development-Summer-2022-CA-94304/702066001) | Various, virtual, in-person | Software Development Intern |
+|[Samsara](https://boards.greenhouse.io/samsara/jobs/3328844) | San Francisco, CA; Atlanta, GA | Software Engineering Intern |
+|[Datadog](https://www.datadoghq.com/careers/detail/?gh_jid=3339295&gh_src=8363eca61) | Boston, Madrid, New York, Paris | Software Engineering Intern |
+|[Quora](https://boards.greenhouse.io/quora/jobs/5438520002) | Remote | Software Engineer Intern, [Machine Learning Intern](https://boards.greenhouse.io/quora/jobs/5451810002)|
+|[Air Products](https://sjobs.brassring.com/TGnewUI/Search/home/HomeWithPreLoad?partnerid=25091&siteid=5105&PageType=JobDetails&jobid=721744#jobDetails=721744_5105) | Allentown, PA | SUMMER INTERN - DIGITAL TECHNOLOGY / IT SPECIALIST |
+| <del> TD Banks </del> |  | **Closed** |
+|[Neocis](https://www.neocis.com/careers/?gnk=job&gni=8a7887a87acffd16017b30a8f2a86cac) | Miami, FL | Software Engineering Intern |
+| <del>Convoy</del> | | **Closed** |
+|[Visa](https://jobs.smartrecruiters.com/Visa/743999765849108-undergrad-intern-technology-multiple-locations?trid=623f64f4-c657-499b-989f-16ab0ccee0d9)| Foster City, CA; San Francisco, CA; Palo Alto, CA; Ashburn, VA; Bellevue, WA; Austin, TX; Highlands Ranch, CO; Atlanta, GA | [Masters/PhD Intern - Technology](https://jobs.smartrecruiters.com/Visa/743999765850221-masters-phd-intern-technology-multiple-locations) |
+|[Anduril](https://jobs.lever.co/anduril/d15840b6-081b-4d4c-95ed-008d681b4f7f) | Seattle, WA | Software Engineering Intern, US Citizen only |
+|[Verkada](https://jobs.lever.co/verkada) | San Mateo, CA | [Backend Software Engineering](https://jobs.lever.co/verkada/8b7f4818-9994-469a-a485-d12d273bff13), [Computer Vision Engineering](https://jobs.lever.co/verkada/857d9e45-626a-44c0-bc8c-4d80bf8dc641), [Embedded Software Engineering](https://jobs.lever.co/verkada/67d4b6d7-7a59-4c8a-a411-d484e0f79e68) and other Intern positions are available. Winter internships are available too. |
+|<del>Steelcase</del> |  | **Closed** |
+|<del> Kapwing </del>|  | **Closed** |
+|[F5 Network](https://f5.recsolu.com/jobs/n2w62aZ-ProSaIPCmlgSMA) | Seattle, WA | Software Engineering Intern |
+|[Wabtec](https://wabtec.wd1.myworkdayjobs.com/wabtec_careers/10/refreshFacet/318c8bb6f553100021d223d9780d30be) | Various | LEAD Information Technology Intern, Engineering Intern. Will not sponsor work visas for some positions. |
+|[Crown Equipment Corporation](https://us-careers.crown.com/job/New-Bremen-Software-Development-Co-Op-Fall-2021-1-OH-45869/776092500/) | New Bremen, OH | Software Development Co-Op. Will not sponsor work visas now or in the future. |
+|[Lyft](https://www.lyft.com/careers#openings?search=intern) | New York, NY; Seattle, WA; San Francisco, CA | Search `"Intern"` - Software Engineer Intern, Frontend; Software Engineer Intern, Generalist. |
+|[Johnson & Johnson](https://jobs.jnj.com/jobs?keywords=Summer%202022&sortBy=relevance&page=1&location=United%20States&woe=12&stretchUnit=MILES&stretch=10) | Various | [R&D](https://jobs.jnj.com/jobs/2105903794W?lang=en-us&previousLocale=en-US), [Technology](https://jobs.jnj.com/jobs/2105956194W?lang=en-us&previousLocale=en-US) Intern positions are available. Candidates must be legally authorized to work in the U.S. and must not require sponsorship for employment visa status now, or in the future. |
+|[3M](https://3m.wd1.myworkdayjobs.com/en-US/Search/job/US-Minnesota-Maplewood/Internship---Undergraduate-Data-Science---Engineering-Intern_R01050492-1) | Maplewood, MN | Undergraduate Data Science & Engineering Intern, [Graduate Data Science & Engineering Intern](https://3m.wd1.myworkdayjobs.com/en-US/Search/job/US-Minnesota-Maplewood/Internship---Graduate-Data-Science---Engineering-Intern_R01050459-1). Some positions require candidate to be legally authorized to work in country of employment without sponsorship for employment visa status (e.g., H1B status). |
+|[Twitch](https://boards.greenhouse.io/twitch/jobs/5471047002#application) | San Francisco, CA | Engineering Intern |
+| <del> Verisk </del> |  | **Closed** |
+|[Snackpass](https://boards.greenhouse.io/snackpass/jobs/4088786004) | New York, San Francisco, Los Angeles, or remote | Data Engineer Intern, [Software Engineer Intern](https://boards.greenhouse.io/snackpass/jobs/4136830004?gh_src=a4465bd04us) |
+|[Roblox](https://corp.roblox.com/careers/listing/?gh_jid=3376216) | San Mateo, CA | Software Engineering Intern, [Data Science Intern](https://corp.roblox.com/careers/listing/?gh_jid=3461439) |
+| <del> Peraton </del> |  | **Closed** |
+|[Noblis](https://careers.noblis.org/listings)| Various | Search `"2022"` - Multiple Location Openings. U.S. citizenship or permanent residency required. |
+|<del>Appian Corp</del> | | **Closed** |
+|<del>Figma</del> | | **Closed** |
+| <del> Rippling </del> | | **Closed**|
+| <del> Principal Financial Group </del> | | **Closed**|
+|[Gem](https://boards.greenhouse.io/zensourcer/jobs/4945378002) | San Francisco, CA | Software Engineering Intern |
+|[Veeva](https://jobs.lever.co/veeva/8d206bef-9caa-41cb-a68d-410912f04865?lever-source=Veeva-Career-Site)|Columbus, Ohio and Pleasanton, CA | Software Engineer Intern. Will not sponsor work visas now or in the future. |
+|<del>Persona</del> | | Closed |
+|[Guardian Life](https://guardian.taleo.net/careersection/gl_ex/jobsearch.ftl) | Various | Multiple openings related to Software Engineering, Cloud, Data Analytics, Cybersecurity. Applicants must be eligible to work in the U.S. without company sponsorship, now or in the future, for employment-based work authorization. |
+|[Honda](https://hondana.taleo.net/careersection/ah_ext/jobdetail.ftl?job=AHM0005QF&tz=GMT-05%3A00&tzname=America%2FChicago) | Various | Information Services Co-op/Intern, [Data Analytics Co-op/Intern](https://hondana.taleo.net/careersection/ah_ext/jobdetail.ftl?job=AHM0005QI&tz=GMT-05%3A00&tzname=America%2FChicago). Sponsorship for employment visa status for these positions is unavailable. |
+| <del> Daktronics </del> |  | **Closed** |
+|[AArete](https://www.aarete.com/join-our-team/open-positions/) | Chicago, IL | [Consulting](https://jobs.jobvite.com/aarete/job/omvCgfwt), [Data Analytics](https://jobs.jobvite.com/aarete/job/owwCgfwE), [Technology](https://jobs.jobvite.com/aarete/job/oTPDgfwl) Intern positions are available. |
+|<del>Snap</del>| |  **Closed** |
+|<del>Quip</del> | | **Closed** |
+|<del>Chime</del>| | **Closed** | 
+| <del> Urban Outfitters </del> |  | **Closed** |
+|[Innovative Systems](http://career.innovativesystems.com/apply/pEU3iGangp/InternCoopSUMMER-2022-Software-Engineering) | Pittsburgh, PA | Software Engineering Intern |
+|[OnPrem Solution Partners](https://jobs.lever.co/onprem.com/2dd1038b-211e-4caf-b9fd-f66ac6bb6117) | Austin, TX | Engineering Intern. Applicants for employment in the US must have work authorization that does not now or in the future require sponsorship of a visa for employment authorization in the United States. |
+| <del>Belcan</del> | | **Closed** |
+|<del>Unilever</del> | United States; Remote | **Closed** Information Technology Intern |
+|[Silicon Labs](https://jobs.jobvite.com/silabs/job/oa8EgfwW) | Austin, TX; Boston, MA | [Applications Engineering](https://jobs.jobvite.com/silabs/job/olSDgfwQ), [Validation Engineering](https://jobs.jobvite.com/silabs/job/oQFEgfw9), [Software Engineering](https://jobs.jobvite.com/silabs/job/oa8EgfwW), [Product Test Engineering](https://jobs.jobvite.com/silabs/job/o38EgfwP) Intern positions are available. |
+|[Zoom](https://zoom.wd5.myworkdayjobs.com/Zoom/1/refreshFacet/318c8bb6f553100021d223d9780d30be) | Various | Search `2022` for multiple positions. Does not sponsor visas |
+|[Zebra Technologies](https://early-careers-zebra.icims.com/jobs/search?ss=1&searchKeyword=2022) | Various | Multiple Intern Openings. Must be authorized to work in the U.S. on a permanent basis without requiring sponsorship. |
+|[TuSimple](https://boards.greenhouse.io/tusimpleinternship) | Tucson, AZ; San Diego, CA | |
+| <del> Ocient </del> |  | **Closed** |
+|[Texas Instruments](https://careers.ti.com/job/13584684/software-engineering-intern-dallas-tx/) | Dallas, TX | Software Engineer Intern. Applicants must have work authorization for the duration of the internship. |
+|<del>Amazon Robotics</del> | | **Closed** |
+|<del>Wells Fargo</del> | | **Closed** |
+|[DataBricks](https://databricks.com/company/careers/open-positions/job?gh_jid=5488591002) | San Francisco, CA | Software Engineer Intern |
+|<del>Pinterest</del>| | **Closed** |
+|<del>Plaid</del> | | **Closed** |
+|[Mastercard](https://mastercard.wd1.myworkdayjobs.com/CorporateCareers/40/refreshFacet/318c8bb6f553100021d223d9780d30be) | New York, Virginia, Missouri | Software Engineer Intern. Must be authorized to work in the U.S. on a permanent basis without requiring sponsorship. |
+|<del>Bloomberg</del>| | **Closed** |
+|[Twilio](https://boards.greenhouse.io/twilio/jobs/3409885)| Various | Software Engineer Intern |
+|[Factset](https://factset.wd1.myworkdayjobs.com/en-US/FactSetCareers/job/New-York-NY-USA/Software-Engineer-Intern---Americas-Campus--Summer-2022-_R12001) | Various | Software Engineer Intern. Only for Undergraduates. |
+|[Leidos](https://careers.leidos.com/search/intern/jobs) | Various | US Citizenship required for Software Developer Intern |
+| <del> Broadway Technology </del> |  | **Closed** |
+| <del> Asurion </del> |  | **Closed** |
+|[Yext](https://boards.greenhouse.io/yext/jobs/3406424) | Washington, D.C | Software Engineering Intern |
+|[PatientCo](https://jobs.lever.co/patientcolife/2dfa196b-65c9-49ba-963f-5c0956cd870d) | Atlanta | Software Engineer Co-op |
+|[24G](https://www.24g.com/careers) | Troy, MI | Search for Engineering Intern in this career page |
+|[ServiceNow](https://jobs.smartrecruiters.com/ServiceNow/743999768965759-software-engineering-internship) | Santa Clara, CA | Software Engineering Intern, Various Positions available |
+|[Quantcast](https://jobs.lever.co/quantcast/f56c1fd6-432b-4fa5-933c-34cdc22ad55d) | SF | Software Engineering Intern |
+| <del> U.S Bank </del> |  | **Closed** |
+|[NetApp](https://netapp.eightfold.ai/careers?pid=8617938&seniority=Intern&domain=netapp.com&triggerGoButton=false) | Various | |
+| <del> FireEye </del> |  | **Closed** |
+|[Uline](https://www.uline.jobs/JobDetails?culture=en&jobid=5648BR&jobtitle=Data-Engineer-Internship---Summer-2022)| Pleasant Prairie, Wisconsin | Data Engineer Internship |
+| <del> Blend </del> | | **Closed**|
+| <del>Motional</del> | | **Closed** |
+|[Hudl](https://boards.greenhouse.io/hudl) | Lincoln, NE | [Software Quality Analyst](https://boards.greenhouse.io/hudl/jobs/3415809), [Software Development](https://boards.greenhouse.io/hudl/jobs/3355652) Intern positions are available. |
+| <del> Paylocity </del> | | **Closed**|
+|[OSISoft](https://osisoft.wd1.myworkdayjobs.com/en-US/osisoft_careers/job/San-Leandro-California-USA/Software-Development-Intern---US_R003277) | San Leandro, California; Johnson City, Tennessee; Philadelphia, Pennsylvania; Scottsdale, Arizona | Software Development Intern. Will not sponsor work visas now or in the future. |
+|[Valkyrie Trading](https://valkyrie-trading.talentify.io/job/software-engineer-intern-summer-2022-chicago-illinois-valkyrie-trading-4da392d5-e1f9-4d0f-8574-aa95e2966875) | Chicago / Illinois | Software Engineer Intern |
+|[Revantage](https://careers-revantage.icims.com/jobs/2847/technology%2c-summer-intern-2022/job?mobile=false&width=930&height=500&bga=true&needsRedirect=false&jan1offset=120&jun1offset=180) | Chicago, IL | Technology Intern |
+|[Chick-fil-a](https://careers-chickfila.icims.com/jobs/search?ss=1&searchKeyword=Intern) | Atlanta, GA | [Digital Transformation and Technology](https://careers-chickfila.icims.com/jobs/10180/2022-digital-transformation-and-technology-summer-intern/job), [Software Engineering](https://careers-chickfila.icims.com/jobs/10181/2022-software-engineering-summer-intern/job?in_iframe=1) Intern positions are available. |
+|[AvidXchange](https://us60.dayforcehcm.com/CandidatePortal/en-us/avidxchange?q=Intern) | Charlotte, NC | [Software Engineering](https://us60.dayforcehcm.com/CandidatePortal/en-us/avidxchange/Posting/View/5047), [Information Security](https://us60.dayforcehcm.com/CandidatePortal/en-us/avidxchange/Posting/View/5046) and other Intern positions are available. |
+|[ZS Associates](https://jobs.zs.com/jobs/10083?lang=en-us) | Various | [Business Technology Solutions Associate - Intern](https://jobs.zs.com/jobs/10083?lang=en-us). Accepts OPT/CPT and will sponsor a work visa in the future. |
+|<del>Deutsche Bank</del> | | **Closed** |
+|<del> General Dynamics Mission Systems </del>| | **Closed** |
+|<del>Rivian</del> | | **Closed** |
+|[DoorDash](https://boards.greenhouse.io/doordash/jobs/3393160?gh_jid=3393160) | Various | Software Engineer Intern |
+|[Mr. Cooper Group](https://careers.mrcooper.com/search/jobs?q=intern) | Dallas, TX | Various Intern Roles. Software Engineer, Devops, Data, Machine Learning. Will not sponsor work visas for some positions. |
+|[UIPath](https://www.uipath.com/company/careers/americas/bellevue/engineering-development/software-engineer-intern)| Bellevue, WA | RPA Developer |
+|<del>Uber</del> |  | **Closed** |
+|<del>Workiva></del> |  | **Closed** |
+|[SingleStore](https://boards.greenhouse.io/singlestore/jobs/3436980) | Raleigh, NC | Software Engineer Intern |
+|[Vail Systems](https://vail-systems.talentify.io/job/web-software-engineer-intern-summer-2022-chicago-illinois-vail-systems-owrkgfwh) | Chicago, Illinois | Web Software Engineer Intern |
+|[Domeyard](https://boards.greenhouse.io/domeyard/jobs/1079185) | Boston, MA | Software Engineer Internship. Will sponsor work visas after your graduation. |
+|[Vermeer](https://vermeer.wd5.myworkdayjobs.com/en-US/externalcareersite/job/Pella-Iowa-USA---Corporate-Office/Embedded-Software-Engineer-Intern---May-2022_REQ-9742) | Pella, Iowa | Embedded Software Engineer Intern. Only accept students majoring in CE, EE, Electronics or Machine Control (CS is excluded). | 
+|<del>Federal Reserve System </del>|  | **Closed** |
+|[WeRide.ai](https://jobs.lever.co/weride/95da0930-7a3e-48fd-80b1-3bf3338a5b56) | San Jose, CA | Software Engineer Intern (Spring/Summer)| 
+|<del>Mutual of Omaha</del>|  | **Closed** |
+|<del> TikTok </del> |  | **Closed** |
+| <del> Microfocus </del> | | **Closed**  |
+|[Linkedin](https://www.linkedin.com/jobs/search/?currentJobId=2705883159&f_C=1337&f_E=1&geoId=90000084&keywords=linkedin&location=San%20Francisco%20Bay%20Area&position=1&pageNum=0) | Sunnyvale, CA | Software Engineer Intern, UI Engineer Intern, Machine Learning Intern, SRE Internship |
+|[Wipfli](https://careers-wipfli.icims.com/jobs/4095/custom-development-internships%2c-summer-2022/job) | Minneapolis, MN; Milwaukee, WI | Custom Development Intern |
+|[Ford Motor Company](https://sjobs.brassring.com/TGnewUI/Search/home/HomeWithPreLoad?partnerid=25385&siteid=5311&PageType=JobDetails&jobid=548716#jobDetails=548716_5311) | Dearborn | Information Technology Software Engineering Intern. Search `"Intern"` as many different positions are there. |
+|<del>DraftKings</del> | | **Closed** |
+|<del> CrowdStrike </del> | | **Closed**|
+|<del>Riot Games</del> | | **Closed** |
+|[John Hopkins APL](https://prdtss.jhuapl.edu/StudentsandRecentGraduates/jobs/2022-technical-college-internship-program-1875) | Laurel, MD | 2022 Technical College Internship Program. US citizenship is required for security clearance. |
+|[Sealed Air Corporation](https://jobs.sealedair.com/search/?createNewAlert=false&q=Summer+2022&locationsearch=United+States) | Charlotte, NC | Software Engineering Intern, Applications Engineering, Data Science Engineering and other Intern positions are available. Some positions require applicant to be permanent US resident or US Citizen or National. |
+|[Ampere](https://amperecomputing.com/apply/) | Various | Software Engineer Intern, Hardware Engineering Intern. |
+|[Schonfeld](https://boards.greenhouse.io/schonfeld?t=e73f47fb1) | New York, NY; Miami, FL | Multiple Positions |
+| <del> Vise </del> |  | **Closed** |
+|<del>Thomson Reuters</del> | | **Closed** |
+|[Viasat](https://careers.viasat.com/careers/FolderDetail/Software-Engineer-Intern/8431) | Germantown, MD | Software Engineer Intern, US Citizenship is required |
+|[TJX](https://jobs.tjx.com/search/?createNewAlert=false&q=Summer+2022&locationsearch=&optionsFacetsDD_country=&optionsFacetsDD_location=&optionsFacetsDD_dept=&optionsFacetsDD_customfield5=&optionsFacetsDD_customfield2=) | Marlborough, MA | Multiple Positions; For Sophomore and Junior students |
+|[Textron](https://textron.taleo.net/careersection/textron/moresearch.ftl) | Fort Worth, TX | Electrical/Computer/Software Engineer. US citizenship required for security clearance. |
+| <del> Discovery Inc </del>|  | **Closed** |
+|[NASA Jet Propulsion Laboratory](https://www.jpl.jobs/search-results?keywords=Intern) | Pasadena, CA | Multiple Positions. Citizens of "designated countries" are not eligible unless they are US Permanent Residents. |
+| <del> McDonald's </del> |  | **Closed** |
+|[MongoDB](https://www.mongodb.com/careers/jobs/3336092) | New York, Austin, SF | Software Engineering Intern |
+|[QVC](https://careers.qurateretailgroup.com/job-search-results/?keyword=2022) | Various | Multiple Openings. |
+|[DriveTime](https://jobs.drivetime.com/jobs?page_size=50&page_number=1&keyword=internship&sort_by=score&sort_order=DESC) | Tempe, AZ | Application Developer, Database Developer, Data Science Developer |
+|[Plexus](https://plexus.wd5.myworkdayjobs.com/en-US/Plexus_Careers/job/Neenah-WI/Intern---Software-Engineer---Summer-2022_R014354) | Neenah, WI | Software Engineer Intern. Few Other Openings too Available.|
+|[Slack](https://slack.com/intl/en-ca/careers/university-recruiting#openings) | Toronto (Canada), San Francisco (USA) | Software Engineer Internship | 
+|[Waymo](https://waymo.com/careers/#software-internships) | Multiple Locations | Software Internships|
+| <del> Geico </del> |  | **Closed** |
+| <del> Indeed </del> |  | **Closed** |
+|[LightBox](https://lightbox.secure.force.com/careers/fRecruit__ApplyJob?vacancyNo=VN097&) | New York, NY; Shelton, CT | Intern, R&D / Python & Data Science. Accepts CPT/OPT and will sponsor a work visa in the future. |
+|[MarketAxess Corporation](https://jobs.smartrecruiters.com/MarketAxess/743999768888675-data-software-engineering-intern-2022) | New York, NY | Data Software Engineer Intern. Accepts CPT/OPT and will sponsor a work visa in the future. |
+|[HP](https://jobs.hp.com/en-us/showjob/jobid/14161/softwareengineerinternship?prefilters=none&CloudSearchLocation=none&CloudSearchValue=none) | Spring(Texas), Fort Collins(Colorado) | Software Engineering Internship |
+|[Xylem](https://jobs.jobvite.com/xylem/job/o3pCgfw4?__jvst=Job%20Board&__jvsd=LinkedIn) | Atlanta, GA; Morrisville, NC; Morton Grave, IL; Seneca Falls, NY | Software Engineer Intern, [Data Science Intern](https://jobs.jobvite.com/xylem/job/ojqCgfwl?__jvst=Job%20Board&__jvsd=LinkedIn) |
+|[Chicago Trading Company](https://ctc.recsolu.com/external/requisitions/97wN1n3TSPbNX8XM5ubNYw) | Chicago, IL | Technology Intern, [Quant Trading Analyst Intern](https://ctc.recsolu.com/external/requisitions/9t6dGDg9NGl6aL31KAaEYw) |
+| <del> American Express </del> |  | **Closed** |
+|[Dimensional Fund Advisors](https://dimensional.wd5.myworkdayjobs.com/en-US/DFA_Campus/job/Austin/Internship-in-Technology-Software-Engineer--Undergraduate---Masters-_2021-6068) | Austin, TX | Internship in Technology-Software Engineer. Accepts CPT/OPT and will sponsor a work visa in the future. |
+|[Anyscale](https://jobs.lever.co/anyscale/31505685-4719-44c5-b7d1-e8409b233da5) | San Francisco, CA | Software Engineer Intern |
+| <del> Snorkel AI </del> |  | **Closed** |
+|[Netflix](https://jobs.netflix.com/jobs/119544498) | Los Gatos, California | [Machine Learning Intern](https://jobs.netflix.com/jobs/119544498), [Analytics Engineering Intern, Data Science and Engineering](https://jobs.netflix.com/jobs/118471558) Note: for MS/PhD only, [Software Engineer Intern](https://jobs.netflix.com/jobs/122369483), [Security SWE](https://jobs.netflix.com/jobs/122369486) |
+|[Slalom](https://jobs.slalom.com//#/post/a0h1R00000Bq2XgQAJ) | Detroit, MI | Software Engineer Intern - Summer 2022 |
+|[Charles Schwab](https://jobs.schwabjobs.com/job/-/-/33727/13744870816?mode=job&iis=Indeed&iisn=IndeedOrganic) | Various | 2022 Technology Internship |
+|[Pella](https://careers.pella.com/jobs/information-technology-intern-summer-2022-4417?src=JB-10080) | Pella, IA | Information Technology Intern / Summer 2022 |
+|<del> Ultimate Kronos Group </del> |  | **Closed** |
+|[Dell](https://dell.wd1.myworkdayjobs.com/ExternalNonPublic/job/Round-Rock-Texas-United-States/Software-Engineering-Intern_R128527) | Round Rock, Seattle, Santa Clara, Hopkinton, Research Triangle Park | Software Engineer Intern |
+|[Squarespace](https://www.squarespace.com/careers/jobs/3401380) | New York, NY | Software Engineer Intern (Backend, Frontend and Internal Infra) |
+|[Publicis Sapient](https://jobs.smartrecruiters.com/ni/PublicisGroupe/1548e7ef-897d-4135-977f-fa400b69e548-software-engineer-intern-class-of-2023) | Various | Junior Software Engineer Intern. Must be legally authorized to work without the need of sponsorship. |
+| <del> Nike </del> | | **Closed** |
+|[ASML](https://www.asml.com/en/careers/internships?query=Summer%202022) | Wilton, CT; San Diego, CA | Software Engineering, Software Development Intern positions are available. |
+|[Aloft](https://jobs.lever.co/aloft/b6356f0c-fc09-4103-879d-537adf5185b0) | Seattle, WA | Software Engineering Intern |
+|[Relativity](https://jobs.lever.co/relativity/93da9a81-2d64-4783-a731-93e2fd12e697?lever-source=LinkedInJobs) | Remote | Software Engineer Intern |
+|[Honeywell](https://honeywell.csod.com/ux/ats/careersite/1/home/requisition/293327?c=honeywell) | Not Specified (US) | Software Engineer Intern/Co-Op
+|[CACI](https://careers.caci.com/global/en/job/CACIGLOBAL253045EXTERNALENGLOBAL/Software-Engineering-Intern-Summer-2022?utm_source=linkedin&utm_medium=phenom-feeds) | Various | Software Engineering Intern – Summer 2022 |
+|[Hilti North America](https://careers.us.hilti.com/en-us/jobs/software-developer-intern) | Plano, TX | Software Developer Intern |
+|[Battelle](https://jobs.battelle.org/job/13816598/software-engineering-intern-summer-2022-columbus-oh/) | Columbus, OH; Chantilly, VA | Software Engineering Intern, [Cyber Engineer Intern](https://jobs.battelle.org/ShowJob/JobId/3047957/Cyber%20Engineer%20Intern%20(Summer%202022)), [Data Science Intern](https://jobs.battelle.org/job/13806048/data-science-intern-summer-2022-columbus-oh/) |
+|[C3.AI](https://boards.greenhouse.io/c3iot/jobs/4086849002) | Redwood, CA | Software Engineer Intern |
+| <del> Duke Energy Corporation </del> |  | **Closed** |
+<del>ByteDance</del> | | **Closed** |
+|[Nutrien](https://retailcareers-nutrien.icims.com/jobs/14787/intern%2c-digital-agronomy-and-data-science/job?mode=job&iis=Job+Posting&iisn=LinkedIn&mobile=false&width=1140&height=500&bga=true&needsRedirect=false&jan1offset=-300&jun1offset=-240) | Champaign, IL | Data Science Intern |
+| <del> Expedia </del> |  | **Closed** |
+| <del> Intel </del> |  | **Closed** |
+| <del>Pocket Gems</del>| | **Closed** |
+| <del> Neeva </del> |  | **Closed** |
+|[SpaceX](https://boards.greenhouse.io/spacex/jobs/5526757002) | Multiple Locations | Software Engineer Inter/Coop; US Citizen Only |
+| <del> Sentry </del> |  | **Closed** |
+|[New Relic](https://jobs.jobvite.com/careers/newrelic/job/ohpNgfwt) | Portland, OR; San Francisco, CA; Atlanta, GA | Undergrad Software Engineer Intern |
+|[Abrigo](http://jobs.jobvite.com/bankerstoolbox/job/ojfMgfwk) | Raleigh, NC;  Austin, TX | Software Engineering Intern |
+| <del> Allegion </del> |  | **Closed** |
+<del>Chan Zuckerberg Initiative</del> | | **Closed** |
+|[Kiva](https://boards.greenhouse.io/kivaorg/jobs/3458616) | Remote | Software Engineering Intern |
+|[OppFi](https://boards.greenhouse.io/opploans/jobs/4701555003) | Chicago, IL; Remote | Software Engineering Internship |
+|[KnowBe4](https://boards.greenhouse.io/knowbe4/jobs/5514774002) | Clearwater, FL | Software Engineer Intern - Frontend, [Software Engineer in Test](https://boards.greenhouse.io/knowbe4/jobs/5514917002) |
+|[Nutanix](https://nutanix.eightfold.ai/careers?pid=8981941&domain=nutanix.com) | San Jose, CA | Software Engineer |
+|[Blue Cross Blue Shield of Michigan](https://ejko.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_3/job/3444) | Detroit, MI | Information Technology/Computer Science Intern |
+| <del> Bentley </del> |  | **Closed** |
+|[Google](https://careers.google.com/jobs/results/?employment_type=INTERN) | Multiple Locations (USA and Canada) | STEP and Software Engineering internships |
+|[Shure Inc](https://careers-shure.icims.com/jobs/2389/application-software-engineering-intern/job) | Niles, IL | Application Software Development Intern, [Embedded Software Development Intern](https://careers-shure.icims.com/jobs/2299/embedded-software-development-intern/job), [Cloud Software Development Intern](https://careers-shure.icims.com/jobs/2349/cloud-software-development-intern/job), [Software Development Intern - Devops](https://careers-shure.icims.com/jobs/2378/software-development-intern-%2528devops%2529/job), [Automated Test Engineering Software Intern](https://careers-shure.icims.com/jobs/2335/automated-test-engineering-software-intern/job) |
+|[X By 2](https://jobs.lever.co/xby2/06041915-a5d6-4741-9ba0-c297d0638a40) | Metro Detroit | Software Engineer Intern |
+| <del> Trimble </del> |  | **Closed** |
+|<del> Victoria's Secret <del> | | **Closed** |
+|[Gordian](https://fortive.taleo.net/careersection/external/jobdetail.ftl?job=TEK010120) | Beaverton, OR | Engineering Intern |
+|[Ginkgo Bioworks](https://jobs.lever.co/ginkgobioworks/f5cd6b3d-e074-40d6-994f-1cf39f469342) | Remote; Boston, MA | Software Engineering Intern |
+|<del> Cloudera </del> | Santa Clara, CA | **Temporarily Closed** Software Engineering Intern |
+| <del> Aegon </del> |  | **Closed** |
+|[TransAmerica](http://careers.transamerica.com/ShowJob/Id/3087958/Data-Science-Intern-(Summer-2022)/) | Denver, CO | Data Science Intern |
+|[Baxter International](https://jobs.baxter.com/job/-/-/152/14153460144) | Round Lake, IL | Software Engineering Intern |
+| <del> iRobot </del> |  | **Closed** |
+|[Northwestern Mutual](https://careers.northwesternmutual.com/corporate-careers/job/software-engineering-internship-summer-2022-milwaukee-wi-corporate-jr-26747/) | Milwaukee, WI | Software Engineering Intern, Undergrad only|
+|[Flatiron](https://flatiron.com/careers/open-positions/3400041) | New York, NY | Software Engineer Intern |
+|<del> Equipment Share </del> |  | **Closed** |
+|[Vectorworks](https://careers-vectorworks.icims.com/jobs/1714/software-engineer-intern-%28summer-2022%29/job?mobile=false&width=980&height=500&bga=true&needsRedirect=false&jan1offset=-300&jun1offset=-240)| Columbia, MD; Remote | Software Engineer Intern |
+|  <del> Aegon </del> |  | **Closed** |
+| [TransAmerica](http://careers.transamerica.com/ShowJob/Id/3087958/Data-Science-Intern-(Summer-2022)/) | Denver, CO | Data Science Intern |
+| [Samsung](https://boards.greenhouse.io/samsungsemiconductor/jobs/4712888003) | San Jose, CA | Software Intern |
+| [Playstation](https://boards.greenhouse.io/sonyinteractiveentertainmentplaystation/jobs/3473563/?t=b8y5ha) | San Francisco, CA; San Diego, CA; San Mateo, CA| Software Engineer Intern, [Software Development Engineer in Test Intern](https://boards.greenhouse.io/sonyinteractiveentertainmentplaystation/jobs/3470463/?t=b8y5ha) |
+| [Genesys](https://genesys.referrals.selectminds.com/jobs/software-engineer-intern-7563?src=JB-10380) | Indianapolis, IN; Durham, NC | Software Engineer Intern |
+| <del> McKesson </del>|  | **Closed** |
+| <del> Toast </del>|  | **Closed** |
+| [Avanade](https://careers.avanade.com/jobsenus/SearchJobs/Summer%202022?3_56_3=19946) | Atlanta, GA; Dallas, TX; Houston, TX; Raleigh, NC | Data Analytics, Cloud Engineer Intern positions are available. |
+| [Intuit](https://jobs.intuit.com/category/interns-and-new-college-grads-jobs/27595/71554/1) | Mountain View, California; San Diego, California | Software Engineer Intern |
+|[Optum](https://careers.unitedhealthgroup.com/job-search-results/?keyword=Intern&parent_category[]=Optum&location=United%20States&country=US&radius=25) | Various| Various tracks are available. For most positions, sponsorship is not available. |
+|[Splunk](https://www.splunk.com/en_us/careers/search-jobs.html?keyword=Summer%202022) | Remote | Solutions Engineering, Product Security, Software Engineering and other Intern positions are available. |
+| <del> [Gap](https://www.gapinc.com/en-us/careers/job-search?query=intern&currentPage=1&sort=score) </del> | | **Closed** |
+| <del> Checkr </del> |  | **Closed** |
+|[Intuitive](https://careers.intuitive.com/us/en/job/214284/Computer-Science-Computer-Engineering-Intern) | Sunnyvale, CA | Computer Science/Computer Engineering Intern. |
+|[Twitter](https://jobs.smartrecruiters.com/ni/Twitter2/f6205ccb-ee15-4669-b8f4-0b773c974c02-2022-engineering-internships-north-america-latin-america) | San Francisco, CA | SWE, Machine Learning, Data Science internships and more! |
+|[Workday](https://workday.wd5.myworkdayjobs.com/en-US/Workday_University_Careers) | Various | SDE, SDET, Application, BA, Product, etc. |
+|[Epic Games](https://boards.greenhouse.io/epicgames?t=8942a4004us)| Various | Various positions  (search intern to view intern openings) |
+|[Pacific Northwest National Laboratory (PNNL)](https://pnnl.jobs/jobs/?q=Intern) | US | Various positions  (search intern to view intern openings) |
+| <del> Instabase </del> | | **Closed** | 
+| <del> Red Hat </del> | | **Closed** |
+| <del> DataChat </del> |  | **Closed** |
+ <del> HashiCorp </del> |  | **Closed** |
+[Brex](https://www.brex.com/careers/engineering/5568153002?gh_jid=5568153002) | United States (Remote) | Software Engineering Intern |
+[Atlassian](https://jobs.lever.co/atlassian/d1ff09b6-1405-450b-8765-ed8306a4e411?trid=1e0b9127-2df6-4b3d-8bc4-d81ae332a601) | Mountain View, US | Software Engineer Intern. Will not sponsor individuals for employment authorization for this job opening. |
+|<del>Square</del> | | **Closed** |
+[T-Mobile](https://www.tmobile.careers/job-details/13873490/uofmagenta-internship-network-technology-assoc-software-engineer-bellevue-wa/) | Various | Associate Software Engineer Intern |
+|<del>American Airlines</del> | | **Closed** |
+|[Second Spectrum](https://secondspectrum.recruitee.com/o/software-engineering-intern-summer-2022) | Remote | Software Engineer Intern |
+|[Bankers Healthcare Group](https://jobs.lever.co/bhg-inc/3916c46c-c64c-4f4a-9e02-bc362e864d3d) | Remote | Data Analytics Intern |
+|<del>FanDuel</del> | | **Closed** |
+|[Voleon](https://jobs.lever.co/voleon/fddcbfab-7541-45ca-8014-295804d47ed8) | Austin | Software Engineer Intern |
+|[Alteryx](https://alteryx.wd5.myworkdayjobs.com/en-US/AlteryxCareers/job/Irvine-California/Software-Engineer-Intern--Summer-2022-_R5679) | Irvine, CA | Software Engineer Intern |
+|[Aurora](https://aurora.tech/careers) | Moutain View, San Francisco, Pittsburgh | Search for "internship" |
+| <del> Analog Devices </del> |  | **Closed** | 
+|[Addepar](https://boards.greenhouse.io/addepar1) | Remote | Multiple positions, go to company job pages and scroll to Interns and New Grads |
+|[Cloudflare](https://www.cloudflare.com/careers/jobs/) | Remote | Software Engineer Intern, Data Engineering and Analytics |
+| <del> Cambly </del> | | **Closed** |
+| <del> Qumulo </del> | | **Closed** |
+|[Pendo](https://boards.greenhouse.io/pendo/jobs/5549592002) | Raleigh, NC | Software Engineering Intern |
+| <del> PathAI </del> | | **Closed** | 
+| <del> Reddit </del> | | **Closed** | 
+| <del> Bodo.ai </del> | | **Closed** |
+|<del>GitLab</del> | Remote | **Closed** |
+|<del> Lumen Technologies </del> | | **Closed** |
+| <del> Yahoo </del> |  | **Closed** |
+|[Unisys](https://jobs.unisys.com/us/en/c/early-careersstudents-jobs?from=10&s=1) | Irvine, CA or Meagean, MI| Software Engineer Intern |
+| <del> MailChimp </del> | | **Closed** |
+|[Adobe](https://adobe.wd5.myworkdayjobs.com/en-US/external_university/details/XMLNAME-2022-Intern---Software-Development-Intern_R116000?jobFamilyGroup=591af8b812fa10737b43a1662896f01c&timeType=262714769a02100a80d2a64ac4e040c0&workerSubType=3ba4ecdf4893100b2f8d08d56d8d6c8e) | San Jose, CA | Software Development Intern |
+| <del> Flexport </del> | | **Closed** |
+|<del>Airbnb</del> | | **Closed** |
+|[Ping Identity](https://recruit.hirebridge.com/v3/Jobs/JobDetails.aspx?cid=7647&jid=560331&locvalue=1011) | Denver, CO | Software Engineer Intern |
+| <del> Certik </del> |  | **Closed** |
+|[Roku](https://www.roku.com/jobs/listing?search=Software&dept=Internships) | San Jose, CA | Software Engineer Intern |
+| <del> Rokt </del> | | **Closed** |
+| <del> Olive </del> | | **Closed** |
+| <del> Duquesne Light </del> |  | **Closed** |
+|<del>Vistaprint</del> | | **Closed** |
+|<del>Snowflake</del> | | **Closed** |
+|[Regeneron Pharmaceuticals](https://careers.regeneron.com/search-results?keywords=Computer%20Science) | Rensselaer, NY; Tarrytown, NY | IT Intern |
+|[Tesla](https://www.tesla.com/careers/search/?query=Summer&department=3&type=3&region=5&country=US) | Palo Alto, CA; <br> Fremont, CA | Various Software and Engineering internships for Spring and Summer 2022 |
+|[Replicon](https://www.replicon.com/job-description/?gnk=job&gni=8a78879e7ce7e84d017d0a4f28470a0e) | Remote | Software Developer Internship |
+| <del> Circle </del> | | **Closed** |
+| <del> Spotify </del> | | **Closed** |
+| <del> Justworks </del> | | **Closed** |
+|[Braze](https://boards.greenhouse.io/braze/jobs/840086?gh_jid=840086) | New York, NY | Software Engineering Intern |
+| <del> Cohesity </del> | | **Closed** |
+|[Autodesk](https://autodesk.wd1.myworkdayjobs.com/uni/1/refreshFacet/318c8bb6f553100021d223d9780d30be) | California, Massachusetts, Portland | Software Engineering (Different Teams) |
+| <del> Equifax </del> | | **Closed** |
+|[Copart](https://recruiting.adp.com/srccar/public/RTI.home?c=1214601&d=ExternalCareerSite#/) | Dallas, TX | Software Engineering Intern |
+| <del> Home Depot </del> | | **Closed** |
+|[Mark43](https://mark43.com/list-job/?gh_jid=1335587)| New York, NY | Software Engineering Intern |
+| <del> Lucid </del> | | **Closed** |
+| <del> Volley </del> | | **Closed** |
+|[Streamforge](https://angel.co/l/2vvkF3) | Remote | Videogames + Influencer Marketing + Twitch Streaming + YouTubers / [Software Engineer Position](https://angel.co/l/2vvkF3) & [Social Media Position](https://angel.co/l/2wM3eh) |
+
+**We love our contributors ❤️❤️**
+
+Fill [this form](https://bit.ly/3d5O76c) or make a [pull request](https://github.com/susam/gitpr#create-pull-request) to help contribute.
+* [JackGoldsworth](https://github.com/JackGoldsworth)
+* [GintasS](https://github.com/gintass)
+* [zhixiangteoh](https://github.com/zhixiangteoh)
+* [CDFalcon](https://github.com/CDFalcon)
+* [Carlwasinfected](https://github.com/Carlwasinfected)
+* [jessicatweneboah](https://github.com/jessicatweneboah)
+* [ksapru](https://github.com/ksapru)
+* [petecao](https://github.com/petecao)
+* [MetricVoid](https://github.com/MetricVoid)
+* [frankhee](https://github.com/frankhee)
+* [kstonekuan](https://github.com/kstonekuan)
+* [itscrystalli](https://github.com/itscrystalli)
+* [LeonSo7](https://github.com/LeonSo7)
+* [deltaprophet](https://github.com/deltaprophet)
+* [dragon-girl88](https://github.com/dragon-girl88)
+* [jameszhang-a](https://github.com/jameszhang-a)
+* [jeffless](https://github.com/jeffless)
+* [Aults](https://github.com/Aults)
+* [EParmar18](https://github.com/EParmar18)
+* [nguyenm2151](https://github.com/nguyenm2151)
+* [Lord-14](https://github.com/Lord-14)
+* [christopherhui](https://github.com/christopherhui)
+* [nihar-joshi](https://github.com/nihar-joshi)
+* [owini](https://github.com/owini)
+* [rkabita](https://github.com/rkabita)
+* [logangeorge01](https://github.com/logangeorge01)
+* [SeojinK1m](https://github.com/SeojinK1m)
+* [enumcase](https://github.com/enumcase)
+* [mghalayini](https://github.com/mghalayini)
+* [ankasengupta](https://github.com/ankasengupta)
+* [yiyangiliu](https://github.com/yiyangiliu)
+* [monishshah18](https://github.com/monishshah18)
+* [Josh0823](https://github.com/Josh0823)
+* [HTian1997](https://github.com/HTian1997)
+* [DeveloperRyan](https://www.github.com/developerryan)
+* [Martje55555](https://github.com/Martje55555)
+* [kvfp](https://github.com/kvfp)
+* [ducdoan510](https://github.com/ducdoan510)
+* [ZhiYingSun](https://github.com/ZhiYingSun)
+* [rohantib](https://github.com/rohantib)
+* [mgayatri77](https://github.com/mgayatri77)
+* [scheng](https://github.com/scheng)
+* [leundai](https://github.com/leundai)
+* [davidteather](https://github.com/davidteather)
+* [danmoop](https://github.com/danmoop)
+* [qc542](https://github.com/qc542)
+* [bekadeveloper](https://github.com/bekadeveloper)
+* [Eurus-Holmes](https://github.com/Eurus-Holmes)
+* [ch2ohch2oh](https://github.com/ch2ohch2oh)
+* [Pochetes](https://github.com/Pochetes)
+* [allen-tran](https://github.com/allen-tran)
+* [BaoLongNguyenUMD](https://github.com/BaoLongNguyenUMD)
+* [nimeshnischal](https://github.com/nimeshnischal)
+* [tson1111](https://github.com/tson1111)
+* [matthewbrown77](https://www.github.com/matthewbrown77)
+* [nikhilkala](https://www.github.com/nikhilkala)
+* [ayoung19](https://github.com/ayoung19)
+* [alexypdu](https://github.com/alexypdu)
+* [yiyiyimu](https://github.com/yiyiyimu)
+* [raymondwzeng](https://github.com/raymondwzeng)
+* [dolnuea](https://github.com/dolnuea)


### PR DESCRIPTION
This PR just adds the READMEs from 2021 and 2022, in case some people may find them helpful (e.g., to know what companies in the past have offered summer internships in the past). I think it's also cool seeing how this repo has evolved since its inception.

Not sure if it's worth adding to the repo, so I'll let someone else decide instead of directly committing this in. 