### PR TITLE
Revert #2107

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,6 @@ And we're back! Use this repo to share and keep track of software, tech, CS, PM,
 | UPS | Atlanta, GA | **🔒 Closed 🔒** Software Engineer Intern |
 | [Snap Inc.](https://wd1.myworkdaysite.com/recruiting/snapchat/snap/job/Los-Angeles-California/Software-Engineering-Intern--Summer-2024_R0032156) | Los Angeles; Palo Alto; Seattle | Software Engineering Intern, Summer 2024 |
 | GE Aerospace | Multiple US Locations | [Digital Technology Intern](https://ge.wd5.myworkdayjobs.com/en-US/GE_ExternalSite/job/GE-Aerospace-US-Digital-Technology-Intern---Summer-2024_R3718425-1) (No Sponsorship) <br/> [Engineering Engines Computer or Software Engineering Intern](https://ge.wd5.myworkdayjobs.com/en-US/GE_ExternalSite/job/GE-Aerospace-Engineering-Engines-Computer-or-Software-Engineering-Intern---Summer-2024_R3726060) (No Sponsorship) <br/> [Systems Engineering Intern](https://ge.wd5.myworkdayjobs.com/en-US/GE_ExternalSite/job/GE-Aerospace-Systems-Engineering-Intern---Summer-2024_R3696296-1) (No Sponsorship) |
-| [Asana](https://boards.greenhouse.io/earlycareerprograms/jobs/5175421?t=fec4559d1us&gh_src=Simplify#app) | NYC, NY | Software Engineering Internship |
 
 <!-- Please leave a one line gap between this and the table -->
 [⬆️ Back to Top ⬆️](https://github.com/pittcsc/Summer2024-Internships#the-list-)


### PR DESCRIPTION
Reverts #2107

Removing Asana's early career internship because I can't find the role on Asana's internship career page: https://asana.com/jobs/university-recruiting. My guess is that Asana is no longer hiring for the role and the link is simply out of date. I'd like to get some eyes on this before we merge this PR, just to be sure that I didn't miss the role by accident