### PR TITLE
Update Eversource Energy locations

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@
 <tr>
 <td><strong><a href="https://simplify.jobs/c/Eversource-Energy?utm_source=GHList&utm_medium=company">Eversource Energy</a></strong></td>
 <td>Software Engineering Intern - Software Engineering</td>
-<td><details><summary><strong>4 locations</strong></summary>Manchester, NH</br>New Britain, CT</br>Hartford, CT</br>Norwood, MA</details></td>
+<td><details><summary><strong>4 locations</strong></summary>Manchester, NH</br>Windsor, CT</br>Berlin, CT</br>Westwood, MA</details></td>
 <td><div align="center"><a href="https://eversource.wd1.myworkdayjobs.com/ExternalSite/job/Windsor-CT/Summer-2026-Software-Engineering-Intern_R-028852?utm_source=Simplify&ref=Simplify"><img src="https://i.imgur.com/fbjwDvo.png" width="50" alt="Apply"></a> <a href="https://simplify.jobs/p/40819d70-60c6-4600-b072-7163488ba28a?utm_source=GHList"><img src="https://i.imgur.com/aVnQdox.png" width="26" alt="Simplify"></a></div></td>
 <td>0d</td>
 </tr>


### PR DESCRIPTION
locations for internships were incorrect, i added the ones that were on the application page. 
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Corrected Eversource Energy internship locations in the README to match the application page and prevent confusion. Updated the list to: Manchester, NH; Windsor, CT; Berlin, CT; Westwood, MA.

<!-- End of auto-generated description by cubic. -->

