### PR TITLE
Updating list: This role is for Chemical Engineering students or Chemistry, …

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,13 +104,6 @@
 <td>0d</td>
 </tr>
 <tr>
-<td><strong><a href="https://simplify.jobs/c/Sherwin-Williams?utm_source=GHList&utm_medium=company">Sherwin-Williams</a></strong></td>
-<td>2026 R&D Product Engineering Co-Op</td>
-<td>Cleveland, OH</td>
-<td><div align="center"><a href="https://ejhp.fa.us6.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_2/jobs/job/2540039?utm_source=Simplify&ref=Simplify"><img src="https://i.imgur.com/fbjwDvo.png" width="50" alt="Apply"></a> <a href="https://simplify.jobs/p/0dc33a3c-4570-4362-a670-f4de783386aa?utm_source=GHList"><img src="https://i.imgur.com/aVnQdox.png" width="26" alt="Simplify"></a></div></td>
-<td>0d</td>
-</tr>
-<tr>
 <td><strong><a href="https://simplify.jobs/c/CACI?utm_source=GHList&utm_medium=company">CACI</a></strong></td>
 <td>Software Engineering Intern - Summer 2026</td>
 <td>Dulles, VA</td>


### PR DESCRIPTION
[Sherwin-Williams] This role is for Chemical Engineering students or Chemistry, …
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Removed the Sherwin-Williams "2026 R&D Product Engineering Co-Op" listing to avoid misleading CS students. The role targets Chemical Engineering/Chemistry, not CS.

<!-- End of auto-generated description by cubic. -->

