### PR TITLE
Clarify US citizenship requirement for NT Concepts

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@
 <td>0d</td>
 </tr>
 <tr>
-<td><strong><a href="https://simplify.jobs/c/NTConcepts?utm_source=GHList&utm_medium=company">NT Concepts</a></strong></td>
+<td>🇺🇸 <strong><a href="https://simplify.jobs/c/NTConcepts?utm_source=GHList&utm_medium=company">NT Concepts</a></strong></td>
 <td>Software Engineer Intern</td>
 <td>Vienna, VA</td>
 <td><div align="center"><a href="https://job-boards.greenhouse.io/ntconcepts/jobs/5743018004?utm_source=Simplify&ref=Simplify"><img src="https://i.imgur.com/fbjwDvo.png" width="50" alt="Apply"></a> <a href="https://simplify.jobs/p/e93560c6-08f4-4406-998b-629c59fb38bd?utm_source=GHList"><img src="https://i.imgur.com/aVnQdox.png" width="26" alt="Simplify"></a></div></td>


### PR DESCRIPTION
This PR clarifies that the NT Concepts internship requires U.S. citizenship.
The update helps candidates quickly identify eligibility requirements and avoids confusion for international applicants.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a 🇺🇸 indicator to the NT Concepts listing to show U.S. citizenship is required. Also fixed the README end-of-file newline.

<sup>Written for commit a8f199d8b27e7ffa6a6aebce8908e6f7e53c00ed. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

