### PR TITLE
Add flag emoji to ICF International internship entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@
 </tr>
 <tr>
 <td><strong><a href="https://simplify.jobs/c/ICF-International?utm_source=GHList&utm_medium=company">ICF International</a></strong></td>
-<td>Intern - AI Engineering</td>
+<td>Intern - AI Engineering 🇺🇸</td>
 <td>Reston, VA</td>
 <td><div align="center"><a href="https://icf.wd5.myworkdayjobs.com/icfexternal_career_site/job/Reston-VA/XMLNAME-2026-Summer-Intern--AI-Engineering_R2600855-1?utm_source=Simplify&ref=Simplify"><img src="https://i.imgur.com/fbjwDvo.png" width="50" alt="Apply"></a> <a href="https://simplify.jobs/p/1ee1e96c-fc1e-4372-9951-f6fc8e88f8e3?utm_source=GHList"><img src="https://i.imgur.com/aVnQdox.png" width="26" alt="Simplify"></a></div></td>
 <td>1d</td>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added a US flag emoji to the ICF International “Intern - AI Engineering” listing to make the US location clear at a glance in the README.

<sup>Written for commit 06982a58a658f852447f7c12a8b1b7ffbb2959d7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

