### PR TITLE
feat: update internship issue template because 2025 is now over 

### DIFF
--- a/.github/ISSUE_TEMPLATE/new_internship.yaml
+++ b/.github/ISSUE_TEMPLATE/new_internship.yaml
@@ -48,8 +48,6 @@ body:
       multiple: true
       options:
         - Summer 2026
-        - Summer 2025
-        - Fall 2025
         - Winter 2026
         - Spring 2026
         - Fall 2026


### PR DESCRIPTION
we do not have time travel capabilities, as you can see

closes #9560 
closes #9609 
<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed "Summer 2025" and "Fall 2025" from the internship issue template to prevent selecting past terms and keep the form current.

<sup>Written for commit 992a3965fd7ecd20722f04505bfd24d645661202. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/SimplifyJobs/Summer2026-Internships/pull/9559?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

