### PR TITLE
docs: fix double space in 'Firmware Developer Co-Op' in README-Off-Season.md

### DIFF
--- a/README-Off-Season.md
+++ b/README-Off-Season.md
@@ -29218,7 +29218,7 @@ We're back! Use this repo to share and keep track of software, tech, CS, PM, qua
 </tr>
 <tr>
 <td><strong><a href="https://simplify.jobs/c/MotorolaSolutions?utm_source=GHList&utm_medium=company">Motorola</a></strong></td>
-<td>Firmware Developer  Co-Op</td>
+<td>Firmware Developer Co-Op</td>
 <td>Vancouver, BC, Canada</td>
 <td>Spring 2026</td>
 <td>🔒</td>


### PR DESCRIPTION
## Summary

This PR fixes a grammar issue in `README-Off-Season.md` (line 29221).

## Problem

Double space between 'Developer' and 'Co-Op' in the firmware developer listing.

The problematic text:

```markdown
Firmware Developer  Co-Op
```

## Fix

Replaced with:

```markdown
Firmware Developer Co-Op
```

## Type of Change

- [x] Documentation fix (grammar, spelling, logical error)
- [ ] Code change
- [ ] Breaking change

## Checklist

- [x] Documentation files only
- [x] No code changes
- [x] Fix verified against original text

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/SimplifyJobs/codesmith/Summer2027-Internships/pr/9671"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788538815&installation_model_id=6807&pr_number=9671&repository=SimplifyJobs%2FSummer2027-Internships&return_to=https%3A%2F%2Fgithub.com%2FSimplifyJobs%2FSummer2027-Internships%2Fpull%2F9671&signature=7f45e1cac73c927c470f8559ef7a7dedf2241d42d3487f4b7248589a4d8b4c76"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed a double space in the Motorola job title in README-Off-Season.md, changing "Firmware Developer  Co-Op" to "Firmware Developer Co-Op" for correct formatting.

<sup>Written for commit 823794e77b4c71d229cc99d7007ad39fdbf6ce90. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/SimplifyJobs/Summer2027-Internships/pull/9671?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

