### PR TITLE
docs: fix 'John Hopkins' to 'Johns Hopkins' in archived/README-2022.md

### DIFF
--- a/archived/README-2022.md
+++ b/archived/README-2022.md
@@ -257,7 +257,7 @@ Use this repo to share and keep track of software, tech, CS, PM, quant internshi
 |<del>DraftKings</del> | | **Closed** |
 |<del> CrowdStrike </del> | | **Closed**|
 |<del>Riot Games</del> | | **Closed** |
-|[John Hopkins APL](https://prdtss.jhuapl.edu/StudentsandRecentGraduates/jobs/2022-technical-college-internship-program-1875) | Laurel, MD | 2022 Technical College Internship Program. US citizenship is required for security clearance. |
+|[Johns Hopkins APL](https://prdtss.jhuapl.edu/StudentsandRecentGraduates/jobs/2022-technical-college-internship-program-1875) | Laurel, MD | 2022 Technical College Internship Program. US citizenship is required for security clearance. |
 |[Sealed Air Corporation](https://jobs.sealedair.com/search/?createNewAlert=false&q=Summer+2022&locationsearch=United+States) | Charlotte, NC | Software Engineering Intern, Applications Engineering, Data Science Engineering and other Intern positions are available. Some positions require applicant to be permanent US resident or US Citizen or National. |
 |[Ampere](https://amperecomputing.com/apply/) | Various | Software Engineer Intern, Hardware Engineering Intern. |
 |[Schonfeld](https://boards.greenhouse.io/schonfeld?t=e73f47fb1) | New York, NY; Miami, FL | Multiple Positions |


### PR DESCRIPTION
## Summary

This PR fixes a grammar issue in `archived/README-2022.md` (line 260).

## Problem

The institution is 'Johns Hopkins' (with an 's' after 'John'), not 'John Hopkins'. The URL contains 'jhuapl' confirming it's Johns Hopkins Applied Physics Laboratory.

The problematic text:

```markdown
John Hopkins APL
```

## Fix

Replaced with:

```markdown
Johns Hopkins APL
```

## Type of Change

- [x] Documentation fix (grammar, spelling, logical error)
- [ ] Code change
- [ ] Breaking change

## Checklist

- [x] Documentation files only
- [x] No code changes
- [x] Fix verified against original text

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/SimplifyJobs/codesmith/Summer2027-Internships/pr/9672"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788538835&installation_model_id=6807&pr_number=9672&repository=SimplifyJobs%2FSummer2027-Internships&return_to=https%3A%2F%2Fgithub.com%2FSimplifyJobs%2FSummer2027-Internships%2Fpull%2F9672&signature=2a6ddd7956a9e10b83e2cc7832579f6939c4d0a04b4827929a172739e68d602a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a naming typo in archived/README-2022.md, updating "John Hopkins APL" to "Johns Hopkins APL". Ensures the 2022 internships table uses the correct institution name.

<sup>Written for commit ecc01ee3fcdca9037455cdb905d32d0bfc671fb4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/SimplifyJobs/Summer2027-Internships/pull/9672?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

