### PR TITLE
docs: fix 'Inter/Coop' to 'Intern/Coop' in archived/README-2022.md

### DIFF
--- a/archived/README-2022.md
+++ b/archived/README-2022.md
@@ -310,7 +310,7 @@ Use this repo to share and keep track of software, tech, CS, PM, quant internshi
 | <del> Intel </del> |  | **Closed** |
 | <del>Pocket Gems</del>| | **Closed** |
 | <del> Neeva </del> |  | **Closed** |
-|[SpaceX](https://boards.greenhouse.io/spacex/jobs/5526757002) | Multiple Locations | Software Engineer Inter/Coop; US Citizen Only |
+|[SpaceX](https://boards.greenhouse.io/spacex/jobs/5526757002) | Multiple Locations | Software Engineer Intern/Coop; US Citizen Only |
 | <del> Sentry </del> |  | **Closed** |
 |[New Relic](https://jobs.jobvite.com/careers/newrelic/job/ohpNgfwt) | Portland, OR; San Francisco, CA; Atlanta, GA | Undergrad Software Engineer Intern |
 |[Abrigo](http://jobs.jobvite.com/bankerstoolbox/job/ojfMgfwk) | Raleigh, NC;  Austin, TX | Software Engineering Intern |


### PR DESCRIPTION
## Summary

This PR fixes a grammar issue in `archived/README-2022.md` (line 313).

## Problem

'Inter/Coop' is missing an 'n' — should be 'Intern/Coop'.

The problematic text:

```markdown
Software Engineer Inter/Coop; US Citizen Only
```

## Fix

Replaced with:

```markdown
Software Engineer Intern/Coop; US Citizen Only
```

## Type of Change

- [x] Documentation fix (grammar, spelling, logical error)
- [ ] Code change
- [ ] Breaking change

## Checklist

- [x] Documentation files only
- [x] No code changes
- [x] Fix verified against original text

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/SimplifyJobs/codesmith/Summer2027-Internships/pr/9673"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788538857&installation_model_id=6807&pr_number=9673&repository=SimplifyJobs%2FSummer2027-Internships&return_to=https%3A%2F%2Fgithub.com%2FSimplifyJobs%2FSummer2027-Internships%2Fpull%2F9673&signature=228e7075752197bd4cc7e891e2a442eb83c4605e69299b7c8678a660c9c9c4d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a typo in `archived/README-2022.md` by changing the SpaceX row from "Software Engineer Inter/Coop; US Citizen Only" to "Software Engineer Intern/Coop; US Citizen Only". This corrects the role title and avoids confusion.

<sup>Written for commit a97d711fa5fb1489589578efc7acb453d87169a9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/SimplifyJobs/Summer2027-Internships/pull/9673?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

